### PR TITLE
Unbreak build on FreeBSD

### DIFF
--- a/negative_tests/core/test_module_errors/src/test_module_errors.cpp
+++ b/negative_tests/core/test_module_errors/src/test_module_errors.cpp
@@ -58,7 +58,7 @@ TEST(
       level_zero_tests::load_binary_file(filename);
   ze_module_desc_t module_description;
   module_description.version = ZE_MODULE_DESC_VERSION_CURRENT;
-  module_description.format = static_cast<ze_module_format_t>(NULL);
+  module_description.format = static_cast<ze_module_format_t>(0);
   module_description.inputSize = static_cast<uint32_t>(binary_file.size());
   module_description.pInputModule = binary_file.data();
   module_description.pBuildFlags = nullptr;


### PR DESCRIPTION
Depends on https://github.com/oneapi-src/level-zero/pull/9. [FreeBSD](https://github.com/freebsd/freebsd/commit/c8ed04c26b6758354853a6bed4629f71d0d01a7d) and [OpenBSD](https://github.com/openbsd/src/commit/6ecde746dea9a5d17abf3bafa06c232b9189b33b) define `NULL` via `nullptr` in C++11 mode.

<details><summary>Tests output (some fail)</summary>

```
test 1
    Start 1: image_tests

1: Test command: utils/image/image_tests
1: Test timeout computed to be: 10000000
1: [==========] Running 21 tests from 7 test cases.
1: [----------] Global test environment set-up.
1: [----------] 2 tests from ImagePNG32Bit
1: [ RUN      ] ImagePNG32Bit.GetPixel
1: [       OK ] ImagePNG32Bit.GetPixel (0 ms)
1: [ RUN      ] ImagePNG32Bit.SetPixel
1: [       OK ] ImagePNG32Bit.SetPixel (0 ms)
1: [----------] 2 tests from ImagePNG32Bit (0 ms total)
1: 
1: [----------] 2 tests from ImageBMP32Bit
1: [ RUN      ] ImageBMP32Bit.GetPixel
1: [       OK ] ImageBMP32Bit.GetPixel (0 ms)
1: [ RUN      ] ImageBMP32Bit.SetPixel
1: [       OK ] ImageBMP32Bit.SetPixel (0 ms)
1: [----------] 2 tests from ImageBMP32Bit (0 ms total)
1: 
1: [----------] 2 tests from ImageBMP8Bit
1: [ RUN      ] ImageBMP8Bit.GetPixel
1: [       OK ] ImageBMP8Bit.GetPixel (0 ms)
1: [ RUN      ] ImageBMP8Bit.SetPixel
1: [       OK ] ImageBMP8Bit.SetPixel (0 ms)
1: [----------] 2 tests from ImageBMP8Bit (0 ms total)
1: 
1: [----------] 3 tests from SizeInBytes/0, where TypeParam = level_zero_tests::ImagePNG<unsigned int>
1: [ RUN      ] SizeInBytes/0.EmptyImage
1: [       OK ] SizeInBytes/0.EmptyImage (0 ms)
1: [ RUN      ] SizeInBytes/0.SinglePixel
1: [       OK ] SizeInBytes/0.SinglePixel (0 ms)
1: [ RUN      ] SizeInBytes/0.MultiplePixels
1: [       OK ] SizeInBytes/0.MultiplePixels (0 ms)
1: [----------] 3 tests from SizeInBytes/0 (0 ms total)
1: 
1: [----------] 3 tests from SizeInBytes/1, where TypeParam = level_zero_tests::ImageBMP<unsigned char>
1: [ RUN      ] SizeInBytes/1.EmptyImage
1: [       OK ] SizeInBytes/1.EmptyImage (0 ms)
1: [ RUN      ] SizeInBytes/1.SinglePixel
1: [       OK ] SizeInBytes/1.SinglePixel (0 ms)
1: [ RUN      ] SizeInBytes/1.MultiplePixels
1: [       OK ] SizeInBytes/1.MultiplePixels (0 ms)
1: [----------] 3 tests from SizeInBytes/1 (0 ms total)
1: 
1: [----------] 3 tests from SizeInBytes/2, where TypeParam = level_zero_tests::ImageBMP<unsigned int>
1: [ RUN      ] SizeInBytes/2.EmptyImage
1: [       OK ] SizeInBytes/2.EmptyImage (0 ms)
1: [ RUN      ] SizeInBytes/2.SinglePixel
1: [       OK ] SizeInBytes/2.SinglePixel (0 ms)
1: [ RUN      ] SizeInBytes/2.MultiplePixels
1: [       OK ] SizeInBytes/2.MultiplePixels (0 ms)
1: [----------] 3 tests from SizeInBytes/2 (0 ms total)
1: 
1: [----------] 6 tests from ImageIntegrationTests
1: [ RUN      ] ImageIntegrationTests.ReadsPNGFile
1: [       OK ] ImageIntegrationTests.ReadsPNGFile (0 ms)
1: [ RUN      ] ImageIntegrationTests.WritesPNGFile
1: [       OK ] ImageIntegrationTests.WritesPNGFile (0 ms)
1: [ RUN      ] ImageIntegrationTests.ReadsGrayscaleBMPFile
1: [       OK ] ImageIntegrationTests.ReadsGrayscaleBMPFile (1 ms)
1: [ RUN      ] ImageIntegrationTests.WritesGrayscaleBMPFile
1: [       OK ] ImageIntegrationTests.WritesGrayscaleBMPFile (0 ms)
1: [ RUN      ] ImageIntegrationTests.ReadsColorBMPFile
1: [       OK ] ImageIntegrationTests.ReadsColorBMPFile (0 ms)
1: [ RUN      ] ImageIntegrationTests.WritesColorBMPFile
1: [       OK ] ImageIntegrationTests.WritesColorBMPFile (0 ms)
1: [----------] 6 tests from ImageIntegrationTests (1 ms total)
1: 
1: [----------] Global test environment tear-down
1: [==========] 21 tests from 7 test cases ran. (1 ms total)
1: [  PASSED  ] 21 tests.
1/4 Test #1: image_tests ......................   Passed    0.00 sec
test 2
    Start 2: logging_tests

2: Test command: utils/logging/logging_tests
2: Test timeout computed to be: 10000000
2: [==========] Running 27 tests from 4 test cases.
2: [----------] Global test environment set-up.
2: [----------] 6 tests from LoggingTest
2: [ RUN      ] LoggingTest.PrintTrace
2: [trace] Message
2: [       OK ] LoggingTest.PrintTrace (0 ms)
2: [ RUN      ] LoggingTest.PrintDebug
2: [debug] Message
2: [       OK ] LoggingTest.PrintDebug (0 ms)
2: [ RUN      ] LoggingTest.PrintInfo
2: [info] Message
2: [       OK ] LoggingTest.PrintInfo (0 ms)
2: [ RUN      ] LoggingTest.PrintWarning
2: [warning] Message
2: [       OK ] LoggingTest.PrintWarning (0 ms)
2: [ RUN      ] LoggingTest.PrintError
2: [error] Message
2: [       OK ] LoggingTest.PrintError (0 ms)
2: [ RUN      ] LoggingTest.PrintFatal
2: [fatal] Message
2: [       OK ] LoggingTest.PrintFatal (0 ms)
2: [----------] 6 tests from LoggingTest (0 ms total)
2: 
2: [----------] 13 tests from LoggingCommandLineParser
2: [ RUN      ] LoggingCommandLineParser.ChooseSimpleFormatFromCommandLine
2: [       OK ] LoggingCommandLineParser.ChooseSimpleFormatFromCommandLine (0 ms)
2: [ RUN      ] LoggingCommandLineParser.ChoosePreciseFormatFromCommandLine
2: [       OK ] LoggingCommandLineParser.ChoosePreciseFormatFromCommandLine (0 ms)
2: [ RUN      ] LoggingCommandLineParser.PreciseFormatIsDefault
2: [       OK ] LoggingCommandLineParser.PreciseFormatIsDefault (0 ms)
2: [ RUN      ] LoggingCommandLineParser.ChooseUnknownFormatFromCommandLine
2: [       OK ] LoggingCommandLineParser.ChooseUnknownFormatFromCommandLine (0 ms)
2: [ RUN      ] LoggingCommandLineParser.ConsumeOnlyKnownOptionsFromCommandLine
2: [       OK ] LoggingCommandLineParser.ConsumeOnlyKnownOptionsFromCommandLine (0 ms)
2: [ RUN      ] LoggingCommandLineParser.ChooseTraceLevelFromCommandLine
2: [       OK ] LoggingCommandLineParser.ChooseTraceLevelFromCommandLine (0 ms)
2: [ RUN      ] LoggingCommandLineParser.ChooseDebugLevelFromCommandLine
2: [       OK ] LoggingCommandLineParser.ChooseDebugLevelFromCommandLine (0 ms)
2: [ RUN      ] LoggingCommandLineParser.ChooseInfoLevelFromCommandLine
2: [       OK ] LoggingCommandLineParser.ChooseInfoLevelFromCommandLine (0 ms)
2: [ RUN      ] LoggingCommandLineParser.ChooseWarningLevelFromCommandLine
2: [       OK ] LoggingCommandLineParser.ChooseWarningLevelFromCommandLine (0 ms)
2: [ RUN      ] LoggingCommandLineParser.ChooseErrorLevelFromCommandLine
2: [       OK ] LoggingCommandLineParser.ChooseErrorLevelFromCommandLine (0 ms)
2: [ RUN      ] LoggingCommandLineParser.ChooseFatalLevelFromCommandLine
2: [       OK ] LoggingCommandLineParser.ChooseFatalLevelFromCommandLine (0 ms)
2: [ RUN      ] LoggingCommandLineParser.InfoLevelIsDefault
2: [       OK ] LoggingCommandLineParser.InfoLevelIsDefault (0 ms)
2: [ RUN      ] LoggingCommandLineParser.ChooseUnknownLevelFromCommandLine
2: [       OK ] LoggingCommandLineParser.ChooseUnknownLevelFromCommandLine (0 ms)
2: [----------] 13 tests from LoggingCommandLineParser (0 ms total)
2: 
2: [----------] 3 tests from LoggingInitTest
2: [ RUN      ] LoggingInitTest.SimpleFormatFromSettings
2: [info] Message
2: [       OK ] LoggingInitTest.SimpleFormatFromSettings (0 ms)
2: [ RUN      ] LoggingInitTest.PreciseFormatFromSettings
2: [2020-04-07 19:05:51] [info] Message
2: [       OK ] LoggingInitTest.PreciseFormatFromSettings (0 ms)
2: [ RUN      ] LoggingInitTest.WarningLevelFromSettings
2: [warning] Message
2: [       OK ] LoggingInitTest.WarningLevelFromSettings (1 ms)
2: [----------] 3 tests from LoggingInitTest (1 ms total)
2: 
2: [----------] 5 tests from VectorToString
2: [ RUN      ] VectorToString.Empty
2: [       OK ] VectorToString.Empty (0 ms)
2: [ RUN      ] VectorToString.SingleElement
2: [       OK ] VectorToString.SingleElement (0 ms)
2: [ RUN      ] VectorToString.MultipleElements
2: [       OK ] VectorToString.MultipleElements (0 ms)
2: [ RUN      ] VectorToString.StringType
2: [       OK ] VectorToString.StringType (0 ms)
2: [ RUN      ] VectorToString.LoggingFormatType
2: [       OK ] VectorToString.LoggingFormatType (0 ms)
2: [----------] 5 tests from VectorToString (0 ms total)
2: 
2: [----------] Global test environment tear-down
2: [==========] 27 tests from 4 test cases ran. (1 ms total)
2: [  PASSED  ] 27 tests.
2/4 Test #2: logging_tests ....................   Passed    0.00 sec
test 3
    Start 3: random_tests

3: Test command: utils/random/random_tests
3: Test timeout computed to be: 10000000
3: [==========] Running 50 tests from 40 test cases.
3: [----------] Global test environment set-up.
3: [----------] 1 test from GenerateIntegerValue/0, where TypeParam = signed char
3: [ RUN      ] GenerateIntegerValue/0.WithinGivenMinAndMaxValue
3: [       OK ] GenerateIntegerValue/0.WithinGivenMinAndMaxValue (0 ms)
3: [----------] 1 test from GenerateIntegerValue/0 (0 ms total)
3: 
3: [----------] 1 test from GenerateIntegerValue/1, where TypeParam = short
3: [ RUN      ] GenerateIntegerValue/1.WithinGivenMinAndMaxValue
3: [       OK ] GenerateIntegerValue/1.WithinGivenMinAndMaxValue (0 ms)
3: [----------] 1 test from GenerateIntegerValue/1 (0 ms total)
3: 
3: [----------] 1 test from GenerateIntegerValue/2, where TypeParam = int
3: [ RUN      ] GenerateIntegerValue/2.WithinGivenMinAndMaxValue
3: [       OK ] GenerateIntegerValue/2.WithinGivenMinAndMaxValue (0 ms)
3: [----------] 1 test from GenerateIntegerValue/2 (0 ms total)
3: 
3: [----------] 1 test from GenerateIntegerValue/3, where TypeParam = long
3: [ RUN      ] GenerateIntegerValue/3.WithinGivenMinAndMaxValue
3: [       OK ] GenerateIntegerValue/3.WithinGivenMinAndMaxValue (0 ms)
3: [----------] 1 test from GenerateIntegerValue/3 (0 ms total)
3: 
3: [----------] 1 test from GenerateIntegerValue/4, where TypeParam = unsigned char
3: [ RUN      ] GenerateIntegerValue/4.WithinGivenMinAndMaxValue
3: [       OK ] GenerateIntegerValue/4.WithinGivenMinAndMaxValue (0 ms)
3: [----------] 1 test from GenerateIntegerValue/4 (0 ms total)
3: 
3: [----------] 1 test from GenerateIntegerValue/5, where TypeParam = unsigned short
3: [ RUN      ] GenerateIntegerValue/5.WithinGivenMinAndMaxValue
3: [       OK ] GenerateIntegerValue/5.WithinGivenMinAndMaxValue (0 ms)
3: [----------] 1 test from GenerateIntegerValue/5 (0 ms total)
3: 
3: [----------] 1 test from GenerateIntegerValue/6, where TypeParam = unsigned int
3: [ RUN      ] GenerateIntegerValue/6.WithinGivenMinAndMaxValue
3: [       OK ] GenerateIntegerValue/6.WithinGivenMinAndMaxValue (0 ms)
3: [----------] 1 test from GenerateIntegerValue/6 (0 ms total)
3: 
3: [----------] 1 test from GenerateIntegerValue/7, where TypeParam = unsigned long
3: [ RUN      ] GenerateIntegerValue/7.WithinGivenMinAndMaxValue
3: [       OK ] GenerateIntegerValue/7.WithinGivenMinAndMaxValue (0 ms)
3: [----------] 1 test from GenerateIntegerValue/7 (0 ms total)
3: 
3: [----------] 1 test from GenerateFloatingPointValue/0, where TypeParam = float
3: [ RUN      ] GenerateFloatingPointValue/0.WithinGivenMinAndMaxValue
3: [       OK ] GenerateFloatingPointValue/0.WithinGivenMinAndMaxValue (0 ms)
3: [----------] 1 test from GenerateFloatingPointValue/0 (0 ms total)
3: 
3: [----------] 1 test from GenerateFloatingPointValue/1, where TypeParam = double
3: [ RUN      ] GenerateFloatingPointValue/1.WithinGivenMinAndMaxValue
3: [       OK ] GenerateFloatingPointValue/1.WithinGivenMinAndMaxValue (0 ms)
3: [----------] 1 test from GenerateFloatingPointValue/1 (0 ms total)
3: 
3: [----------] 1 test from GenerateValue/0, where TypeParam = signed char
3: [ RUN      ] GenerateValue/0.WithinTypeMinAndMaxValue
3: [       OK ] GenerateValue/0.WithinTypeMinAndMaxValue (0 ms)
3: [----------] 1 test from GenerateValue/0 (0 ms total)
3: 
3: [----------] 1 test from GenerateValue/1, where TypeParam = short
3: [ RUN      ] GenerateValue/1.WithinTypeMinAndMaxValue
3: [       OK ] GenerateValue/1.WithinTypeMinAndMaxValue (0 ms)
3: [----------] 1 test from GenerateValue/1 (0 ms total)
3: 
3: [----------] 1 test from GenerateValue/2, where TypeParam = int
3: [ RUN      ] GenerateValue/2.WithinTypeMinAndMaxValue
3: [       OK ] GenerateValue/2.WithinTypeMinAndMaxValue (0 ms)
3: [----------] 1 test from GenerateValue/2 (0 ms total)
3: 
3: [----------] 1 test from GenerateValue/3, where TypeParam = long
3: [ RUN      ] GenerateValue/3.WithinTypeMinAndMaxValue
3: [       OK ] GenerateValue/3.WithinTypeMinAndMaxValue (0 ms)
3: [----------] 1 test from GenerateValue/3 (0 ms total)
3: 
3: [----------] 1 test from GenerateValue/4, where TypeParam = unsigned char
3: [ RUN      ] GenerateValue/4.WithinTypeMinAndMaxValue
3: [       OK ] GenerateValue/4.WithinTypeMinAndMaxValue (0 ms)
3: [----------] 1 test from GenerateValue/4 (0 ms total)
3: 
3: [----------] 1 test from GenerateValue/5, where TypeParam = unsigned short
3: [ RUN      ] GenerateValue/5.WithinTypeMinAndMaxValue
3: [       OK ] GenerateValue/5.WithinTypeMinAndMaxValue (0 ms)
3: [----------] 1 test from GenerateValue/5 (0 ms total)
3: 
3: [----------] 1 test from GenerateValue/6, where TypeParam = unsigned int
3: [ RUN      ] GenerateValue/6.WithinTypeMinAndMaxValue
3: [       OK ] GenerateValue/6.WithinTypeMinAndMaxValue (0 ms)
3: [----------] 1 test from GenerateValue/6 (0 ms total)
3: 
3: [----------] 1 test from GenerateValue/7, where TypeParam = unsigned long
3: [ RUN      ] GenerateValue/7.WithinTypeMinAndMaxValue
3: [       OK ] GenerateValue/7.WithinTypeMinAndMaxValue (0 ms)
3: [----------] 1 test from GenerateValue/7 (0 ms total)
3: 
3: [----------] 1 test from GenerateValue/8, where TypeParam = float
3: [ RUN      ] GenerateValue/8.WithinTypeMinAndMaxValue
3: [       OK ] GenerateValue/8.WithinTypeMinAndMaxValue (0 ms)
3: [----------] 1 test from GenerateValue/8 (0 ms total)
3: 
3: [----------] 1 test from GenerateValue/9, where TypeParam = double
3: [ RUN      ] GenerateValue/9.WithinTypeMinAndMaxValue
3: [       OK ] GenerateValue/9.WithinTypeMinAndMaxValue (0 ms)
3: [----------] 1 test from GenerateValue/9 (0 ms total)
3: 
3: [----------] 1 test from GenerateIntegerVector/0, where TypeParam = signed char
3: [ RUN      ] GenerateIntegerVector/0.WithinGivenMinAndMaxValue
3: [       OK ] GenerateIntegerVector/0.WithinGivenMinAndMaxValue (0 ms)
3: [----------] 1 test from GenerateIntegerVector/0 (0 ms total)
3: 
3: [----------] 1 test from GenerateIntegerVector/1, where TypeParam = short
3: [ RUN      ] GenerateIntegerVector/1.WithinGivenMinAndMaxValue
3: [       OK ] GenerateIntegerVector/1.WithinGivenMinAndMaxValue (0 ms)
3: [----------] 1 test from GenerateIntegerVector/1 (0 ms total)
3: 
3: [----------] 1 test from GenerateIntegerVector/2, where TypeParam = int
3: [ RUN      ] GenerateIntegerVector/2.WithinGivenMinAndMaxValue
3: [       OK ] GenerateIntegerVector/2.WithinGivenMinAndMaxValue (0 ms)
3: [----------] 1 test from GenerateIntegerVector/2 (0 ms total)
3: 
3: [----------] 1 test from GenerateIntegerVector/3, where TypeParam = long
3: [ RUN      ] GenerateIntegerVector/3.WithinGivenMinAndMaxValue
3: [       OK ] GenerateIntegerVector/3.WithinGivenMinAndMaxValue (0 ms)
3: [----------] 1 test from GenerateIntegerVector/3 (0 ms total)
3: 
3: [----------] 1 test from GenerateIntegerVector/4, where TypeParam = unsigned char
3: [ RUN      ] GenerateIntegerVector/4.WithinGivenMinAndMaxValue
3: [       OK ] GenerateIntegerVector/4.WithinGivenMinAndMaxValue (0 ms)
3: [----------] 1 test from GenerateIntegerVector/4 (0 ms total)
3: 
3: [----------] 1 test from GenerateIntegerVector/5, where TypeParam = unsigned short
3: [ RUN      ] GenerateIntegerVector/5.WithinGivenMinAndMaxValue
3: [       OK ] GenerateIntegerVector/5.WithinGivenMinAndMaxValue (0 ms)
3: [----------] 1 test from GenerateIntegerVector/5 (0 ms total)
3: 
3: [----------] 1 test from GenerateIntegerVector/6, where TypeParam = unsigned int
3: [ RUN      ] GenerateIntegerVector/6.WithinGivenMinAndMaxValue
3: [       OK ] GenerateIntegerVector/6.WithinGivenMinAndMaxValue (0 ms)
3: [----------] 1 test from GenerateIntegerVector/6 (0 ms total)
3: 
3: [----------] 1 test from GenerateIntegerVector/7, where TypeParam = unsigned long
3: [ RUN      ] GenerateIntegerVector/7.WithinGivenMinAndMaxValue
3: [       OK ] GenerateIntegerVector/7.WithinGivenMinAndMaxValue (0 ms)
3: [----------] 1 test from GenerateIntegerVector/7 (0 ms total)
3: 
3: [----------] 1 test from GenerateFloatingPointVector/0, where TypeParam = float
3: [ RUN      ] GenerateFloatingPointVector/0.WithinGivenMinAndMaxValue
3: [       OK ] GenerateFloatingPointVector/0.WithinGivenMinAndMaxValue (0 ms)
3: [----------] 1 test from GenerateFloatingPointVector/0 (0 ms total)
3: 
3: [----------] 1 test from GenerateFloatingPointVector/1, where TypeParam = double
3: [ RUN      ] GenerateFloatingPointVector/1.WithinGivenMinAndMaxValue
3: [       OK ] GenerateFloatingPointVector/1.WithinGivenMinAndMaxValue (0 ms)
3: [----------] 1 test from GenerateFloatingPointVector/1 (0 ms total)
3: 
3: [----------] 2 tests from GenerateVector/0, where TypeParam = signed char
3: [ RUN      ] GenerateVector/0.WithinTypeMinAndMaxValue
3: [       OK ] GenerateVector/0.WithinTypeMinAndMaxValue (0 ms)
3: [ RUN      ] GenerateVector/0.WithExpectedSize
3: [       OK ] GenerateVector/0.WithExpectedSize (0 ms)
3: [----------] 2 tests from GenerateVector/0 (0 ms total)
3: 
3: [----------] 2 tests from GenerateVector/1, where TypeParam = short
3: [ RUN      ] GenerateVector/1.WithinTypeMinAndMaxValue
3: [       OK ] GenerateVector/1.WithinTypeMinAndMaxValue (0 ms)
3: [ RUN      ] GenerateVector/1.WithExpectedSize
3: [       OK ] GenerateVector/1.WithExpectedSize (0 ms)
3: [----------] 2 tests from GenerateVector/1 (0 ms total)
3: 
3: [----------] 2 tests from GenerateVector/2, where TypeParam = int
3: [ RUN      ] GenerateVector/2.WithinTypeMinAndMaxValue
3: [       OK ] GenerateVector/2.WithinTypeMinAndMaxValue (0 ms)
3: [ RUN      ] GenerateVector/2.WithExpectedSize
3: [       OK ] GenerateVector/2.WithExpectedSize (0 ms)
3: [----------] 2 tests from GenerateVector/2 (0 ms total)
3: 
3: [----------] 2 tests from GenerateVector/3, where TypeParam = long
3: [ RUN      ] GenerateVector/3.WithinTypeMinAndMaxValue
3: [       OK ] GenerateVector/3.WithinTypeMinAndMaxValue (0 ms)
3: [ RUN      ] GenerateVector/3.WithExpectedSize
3: [       OK ] GenerateVector/3.WithExpectedSize (0 ms)
3: [----------] 2 tests from GenerateVector/3 (0 ms total)
3: 
3: [----------] 2 tests from GenerateVector/4, where TypeParam = unsigned char
3: [ RUN      ] GenerateVector/4.WithinTypeMinAndMaxValue
3: [       OK ] GenerateVector/4.WithinTypeMinAndMaxValue (0 ms)
3: [ RUN      ] GenerateVector/4.WithExpectedSize
3: [       OK ] GenerateVector/4.WithExpectedSize (0 ms)
3: [----------] 2 tests from GenerateVector/4 (0 ms total)
3: 
3: [----------] 2 tests from GenerateVector/5, where TypeParam = unsigned short
3: [ RUN      ] GenerateVector/5.WithinTypeMinAndMaxValue
3: [       OK ] GenerateVector/5.WithinTypeMinAndMaxValue (0 ms)
3: [ RUN      ] GenerateVector/5.WithExpectedSize
3: [       OK ] GenerateVector/5.WithExpectedSize (0 ms)
3: [----------] 2 tests from GenerateVector/5 (0 ms total)
3: 
3: [----------] 2 tests from GenerateVector/6, where TypeParam = unsigned int
3: [ RUN      ] GenerateVector/6.WithinTypeMinAndMaxValue
3: [       OK ] GenerateVector/6.WithinTypeMinAndMaxValue (0 ms)
3: [ RUN      ] GenerateVector/6.WithExpectedSize
3: [       OK ] GenerateVector/6.WithExpectedSize (0 ms)
3: [----------] 2 tests from GenerateVector/6 (0 ms total)
3: 
3: [----------] 2 tests from GenerateVector/7, where TypeParam = unsigned long
3: [ RUN      ] GenerateVector/7.WithinTypeMinAndMaxValue
3: [       OK ] GenerateVector/7.WithinTypeMinAndMaxValue (0 ms)
3: [ RUN      ] GenerateVector/7.WithExpectedSize
3: [       OK ] GenerateVector/7.WithExpectedSize (0 ms)
3: [----------] 2 tests from GenerateVector/7 (0 ms total)
3: 
3: [----------] 2 tests from GenerateVector/8, where TypeParam = float
3: [ RUN      ] GenerateVector/8.WithinTypeMinAndMaxValue
3: [       OK ] GenerateVector/8.WithinTypeMinAndMaxValue (0 ms)
3: [ RUN      ] GenerateVector/8.WithExpectedSize
3: [       OK ] GenerateVector/8.WithExpectedSize (0 ms)
3: [----------] 2 tests from GenerateVector/8 (0 ms total)
3: 
3: [----------] 2 tests from GenerateVector/9, where TypeParam = double
3: [ RUN      ] GenerateVector/9.WithinTypeMinAndMaxValue
3: [       OK ] GenerateVector/9.WithinTypeMinAndMaxValue (0 ms)
3: [ RUN      ] GenerateVector/9.WithExpectedSize
3: [       OK ] GenerateVector/9.WithExpectedSize (0 ms)
3: [----------] 2 tests from GenerateVector/9 (0 ms total)
3: 
3: [----------] Global test environment tear-down
3: [==========] 50 tests from 40 test cases ran. (1 ms total)
3: [  PASSED  ] 50 tests.
3/4 Test #3: random_tests .....................   Passed    0.00 sec
test 4
    Start 4: utils_tests

4: Test command: utils/utils/utils_tests
4: Test timeout computed to be: 10000000
4: [==========] Running 116 tests from 24 test cases.
4: [----------] Global test environment set-up.
4: [----------] 3 tests from SizeInBytes/0, where TypeParam = unsigned char
4: [ RUN      ] SizeInBytes/0.EmptyVector
4: [       OK ] SizeInBytes/0.EmptyVector (0 ms)
4: [ RUN      ] SizeInBytes/0.SingleElement
4: [       OK ] SizeInBytes/0.SingleElement (0 ms)
4: [ RUN      ] SizeInBytes/0.MultipleElements
4: [       OK ] SizeInBytes/0.MultipleElements (0 ms)
4: [----------] 3 tests from SizeInBytes/0 (0 ms total)
4: 
4: [----------] 3 tests from SizeInBytes/1, where TypeParam = signed char
4: [ RUN      ] SizeInBytes/1.EmptyVector
4: [       OK ] SizeInBytes/1.EmptyVector (0 ms)
4: [ RUN      ] SizeInBytes/1.SingleElement
4: [       OK ] SizeInBytes/1.SingleElement (0 ms)
4: [ RUN      ] SizeInBytes/1.MultipleElements
4: [       OK ] SizeInBytes/1.MultipleElements (0 ms)
4: [----------] 3 tests from SizeInBytes/1 (0 ms total)
4: 
4: [----------] 3 tests from SizeInBytes/2, where TypeParam = unsigned short
4: [ RUN      ] SizeInBytes/2.EmptyVector
4: [       OK ] SizeInBytes/2.EmptyVector (0 ms)
4: [ RUN      ] SizeInBytes/2.SingleElement
4: [       OK ] SizeInBytes/2.SingleElement (0 ms)
4: [ RUN      ] SizeInBytes/2.MultipleElements
4: [       OK ] SizeInBytes/2.MultipleElements (0 ms)
4: [----------] 3 tests from SizeInBytes/2 (0 ms total)
4: 
4: [----------] 3 tests from SizeInBytes/3, where TypeParam = short
4: [ RUN      ] SizeInBytes/3.EmptyVector
4: [       OK ] SizeInBytes/3.EmptyVector (0 ms)
4: [ RUN      ] SizeInBytes/3.SingleElement
4: [       OK ] SizeInBytes/3.SingleElement (0 ms)
4: [ RUN      ] SizeInBytes/3.MultipleElements
4: [       OK ] SizeInBytes/3.MultipleElements (0 ms)
4: [----------] 3 tests from SizeInBytes/3 (0 ms total)
4: 
4: [----------] 3 tests from SizeInBytes/4, where TypeParam = unsigned int
4: [ RUN      ] SizeInBytes/4.EmptyVector
4: [       OK ] SizeInBytes/4.EmptyVector (0 ms)
4: [ RUN      ] SizeInBytes/4.SingleElement
4: [       OK ] SizeInBytes/4.SingleElement (0 ms)
4: [ RUN      ] SizeInBytes/4.MultipleElements
4: [       OK ] SizeInBytes/4.MultipleElements (0 ms)
4: [----------] 3 tests from SizeInBytes/4 (0 ms total)
4: 
4: [----------] 3 tests from SizeInBytes/5, where TypeParam = short
4: [ RUN      ] SizeInBytes/5.EmptyVector
4: [       OK ] SizeInBytes/5.EmptyVector (0 ms)
4: [ RUN      ] SizeInBytes/5.SingleElement
4: [       OK ] SizeInBytes/5.SingleElement (0 ms)
4: [ RUN      ] SizeInBytes/5.MultipleElements
4: [       OK ] SizeInBytes/5.MultipleElements (0 ms)
4: [----------] 3 tests from SizeInBytes/5 (0 ms total)
4: 
4: [----------] 3 tests from SizeInBytes/6, where TypeParam = unsigned long
4: [ RUN      ] SizeInBytes/6.EmptyVector
4: [       OK ] SizeInBytes/6.EmptyVector (0 ms)
4: [ RUN      ] SizeInBytes/6.SingleElement
4: [       OK ] SizeInBytes/6.SingleElement (0 ms)
4: [ RUN      ] SizeInBytes/6.MultipleElements
4: [       OK ] SizeInBytes/6.MultipleElements (0 ms)
4: [----------] 3 tests from SizeInBytes/6 (0 ms total)
4: 
4: [----------] 3 tests from SizeInBytes/7, where TypeParam = long
4: [ RUN      ] SizeInBytes/7.EmptyVector
4: [       OK ] SizeInBytes/7.EmptyVector (0 ms)
4: [ RUN      ] SizeInBytes/7.SingleElement
4: [       OK ] SizeInBytes/7.SingleElement (0 ms)
4: [ RUN      ] SizeInBytes/7.MultipleElements
4: [       OK ] SizeInBytes/7.MultipleElements (0 ms)
4: [----------] 3 tests from SizeInBytes/7 (0 ms total)
4: 
4: [----------] 3 tests from SizeInBytes/8, where TypeParam = float
4: [ RUN      ] SizeInBytes/8.EmptyVector
4: [       OK ] SizeInBytes/8.EmptyVector (0 ms)
4: [ RUN      ] SizeInBytes/8.SingleElement
4: [       OK ] SizeInBytes/8.SingleElement (0 ms)
4: [ RUN      ] SizeInBytes/8.MultipleElements
4: [       OK ] SizeInBytes/8.MultipleElements (0 ms)
4: [----------] 3 tests from SizeInBytes/8 (0 ms total)
4: 
4: [----------] 3 tests from SizeInBytes/9, where TypeParam = double
4: [ RUN      ] SizeInBytes/9.EmptyVector
4: [       OK ] SizeInBytes/9.EmptyVector (0 ms)
4: [ RUN      ] SizeInBytes/9.SingleElement
4: [       OK ] SizeInBytes/9.SingleElement (0 ms)
4: [ RUN      ] SizeInBytes/9.MultipleElements
4: [       OK ] SizeInBytes/9.MultipleElements (0 ms)
4: [----------] 3 tests from SizeInBytes/9 (0 ms total)
4: 
4: [----------] 1 test from XeApiVersionToString
4: [ RUN      ] XeApiVersionToString.ZE_API_VERSION_1_0
4: utils/utils/test/utils_unit_tests.cpp:37: Failure
4: Expected equality of these values:
4:   "1.0"
4:   level_zero_tests::to_string(v)
4:     Which is: "0.91"
4: [  FAILED  ] XeApiVersionToString.ZE_API_VERSION_1_0 (0 ms)
4: [----------] 1 test from XeApiVersionToString (0 ms total)
4: 
4: [----------] 10 tests from XeResultToString
4: [ RUN      ] XeResultToString.ZE_RESULT_SUCCESS
4: [       OK ] XeResultToString.ZE_RESULT_SUCCESS (0 ms)
4: [ RUN      ] XeResultToString.ZE_RESULT_NOT_READY
4: [       OK ] XeResultToString.ZE_RESULT_NOT_READY (0 ms)
4: [ RUN      ] XeResultToString.ZE_RESULT_ERROR_UNINITIALIZED
4: [       OK ] XeResultToString.ZE_RESULT_ERROR_UNINITIALIZED (0 ms)
4: [ RUN      ] XeResultToString.ZE_RESULT_ERROR_DEVICE_LOST
4: [       OK ] XeResultToString.ZE_RESULT_ERROR_DEVICE_LOST (0 ms)
4: [ RUN      ] XeResultToString.ZE_RESULT_ERROR_INVALID_ARGUMENT
4: utils/utils/test/utils_unit_tests.cpp:63: Failure
4: Expected equality of these values:
4:   "ZE_RESULT_ERROR_INVALID_ARGUMENT "
4:   level_zero_tests::to_string(r)
4:     Which is: "ZE_RESULT_ERROR_INVALID_ARGUMENT"
4: [  FAILED  ] XeResultToString.ZE_RESULT_ERROR_INVALID_ARGUMENT (0 ms)
4: [ RUN      ] XeResultToString.ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY
4: [       OK ] XeResultToString.ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY (0 ms)
4: [ RUN      ] XeResultToString.ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
4: [       OK ] XeResultToString.ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY (0 ms)
4: [ RUN      ] XeResultToString.ZE_RESULT_ERROR_MODULE_BUILD_FAILURE
4: [       OK ] XeResultToString.ZE_RESULT_ERROR_MODULE_BUILD_FAILURE (0 ms)
4: [ RUN      ] XeResultToString.ZE_RESULT_ERROR_UNKNOWN
4: [       OK ] XeResultToString.ZE_RESULT_ERROR_UNKNOWN (0 ms)
4: [ RUN      ] XeResultToString.InvalidValue
4: [       OK ] XeResultToString.InvalidValue (0 ms)
4: [----------] 10 tests from XeResultToString (0 ms total)
4: 
4: [----------] 2 tests from XeCommandQueueDescVersionToString
4: [ RUN      ] XeCommandQueueDescVersionToString.ZE_COMMAND_QUEUE_DESC_VERSION_CURRENT
4: [       OK ] XeCommandQueueDescVersionToString.ZE_COMMAND_QUEUE_DESC_VERSION_CURRENT (0 ms)
4: [ RUN      ] XeCommandQueueDescVersionToString.NonCurrentDescVersion
4: [       OK ] XeCommandQueueDescVersionToString.NonCurrentDescVersion (0 ms)
4: [----------] 2 tests from XeCommandQueueDescVersionToString (0 ms total)
4: 
4: [----------] 2 tests from XeCommandQueueDescFlagsToString
4: [ RUN      ] XeCommandQueueDescFlagsToString.ZE_COMMAND_QUEUE_FLAG_COPY_ONLY
4: [       OK ] XeCommandQueueDescFlagsToString.ZE_COMMAND_QUEUE_FLAG_COPY_ONLY (0 ms)
4: [ RUN      ] XeCommandQueueDescFlagsToString.InvalidValue
4: [       OK ] XeCommandQueueDescFlagsToString.InvalidValue (0 ms)
4: [----------] 2 tests from XeCommandQueueDescFlagsToString (0 ms total)
4: 
4: [----------] 2 tests from XeCommandQueueDescModeToString
4: [ RUN      ] XeCommandQueueDescModeToString.ZE_COMMAND_QUEUE_MODE_SYNCHRONOUS
4: [       OK ] XeCommandQueueDescModeToString.ZE_COMMAND_QUEUE_MODE_SYNCHRONOUS (0 ms)
4: [ RUN      ] XeCommandQueueDescModeToString.InvalidValue
4: [       OK ] XeCommandQueueDescModeToString.InvalidValue (0 ms)
4: [----------] 2 tests from XeCommandQueueDescModeToString (0 ms total)
4: 
4: [----------] 2 tests from XeCommandQueueDescPriorityToString
4: [ RUN      ] XeCommandQueueDescPriorityToString.ZE_COMMAND_QUEUE_PRIORITY_LOW
4: [       OK ] XeCommandQueueDescPriorityToString.ZE_COMMAND_QUEUE_PRIORITY_LOW (0 ms)
4: [ RUN      ] XeCommandQueueDescPriorityToString.InvalidValue
4: [       OK ] XeCommandQueueDescPriorityToString.InvalidValue (0 ms)
4: [----------] 2 tests from XeCommandQueueDescPriorityToString (0 ms total)
4: 
4: [----------] 2 tests from XeImageDescVersionToString
4: [ RUN      ] XeImageDescVersionToString.ZE_IMAGE_DESC_VERSION_CURRENT
4: [       OK ] XeImageDescVersionToString.ZE_IMAGE_DESC_VERSION_CURRENT (0 ms)
4: [ RUN      ] XeImageDescVersionToString.NonCurrentDescVersion
4: [       OK ] XeImageDescVersionToString.NonCurrentDescVersion (0 ms)
4: [----------] 2 tests from XeImageDescVersionToString (0 ms total)
4: 
4: [----------] 31 tests from XeImageFormatLayoutToString
4: [ RUN      ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_8
4: [       OK ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_8 (0 ms)
4: [ RUN      ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_16
4: [       OK ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_16 (0 ms)
4: [ RUN      ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_32
4: [       OK ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_32 (0 ms)
4: [ RUN      ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_8_8
4: [       OK ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_8_8 (0 ms)
4: [ RUN      ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_8_8_8_8
4: [       OK ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_8_8_8_8 (0 ms)
4: [ RUN      ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_16_16
4: [       OK ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_16_16 (0 ms)
4: [ RUN      ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_16_16_16_16
4: [       OK ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_16_16_16_16 (0 ms)
4: [ RUN      ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_32_32
4: [       OK ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_32_32 (0 ms)
4: [ RUN      ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_32_32_32_32
4: [       OK ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_32_32_32_32 (0 ms)
4: [ RUN      ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_10_10_10_2
4: [       OK ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_10_10_10_2 (0 ms)
4: [ RUN      ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_11_11_10
4: [       OK ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_11_11_10 (0 ms)
4: [ RUN      ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_5_6_5
4: [       OK ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_5_6_5 (0 ms)
4: [ RUN      ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_5_5_5_1
4: [       OK ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_5_5_5_1 (0 ms)
4: [ RUN      ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_4_4_4_4
4: [       OK ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_4_4_4_4 (0 ms)
4: [ RUN      ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_Y8
4: [       OK ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_Y8 (0 ms)
4: [ RUN      ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_NV12
4: [       OK ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_NV12 (0 ms)
4: [ RUN      ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_YUYV
4: [       OK ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_YUYV (0 ms)
4: [ RUN      ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_VYUY
4: [       OK ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_VYUY (0 ms)
4: [ RUN      ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_YVYU
4: [       OK ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_YVYU (0 ms)
4: [ RUN      ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_UYVY
4: [       OK ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_UYVY (0 ms)
4: [ RUN      ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_AYUV
4: [       OK ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_AYUV (0 ms)
4: [ RUN      ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_YUAV
4: [       OK ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_YUAV (0 ms)
4: [ RUN      ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_P010
4: [       OK ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_P010 (0 ms)
4: [ RUN      ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_Y410
4: [       OK ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_Y410 (0 ms)
4: [ RUN      ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_P012
4: [       OK ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_P012 (0 ms)
4: [ RUN      ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_Y16
4: [       OK ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_Y16 (0 ms)
4: [ RUN      ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_P016
4: [       OK ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_P016 (0 ms)
4: [ RUN      ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_Y216
4: [       OK ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_Y216 (0 ms)
4: [ RUN      ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_P216
4: [       OK ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_P216 (0 ms)
4: [ RUN      ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_P416
4: [       OK ] XeImageFormatLayoutToString.ZE_IMAGE_FORMAT_LAYOUT_P416 (0 ms)
4: [ RUN      ] XeImageFormatLayoutToString.InvalidValue
4: [       OK ] XeImageFormatLayoutToString.InvalidValue (0 ms)
4: [----------] 31 tests from XeImageFormatLayoutToString (0 ms total)
4: 
4: [----------] 6 tests from XeImageFormatTypeToString
4: [ RUN      ] XeImageFormatTypeToString.ZE_IMAGE_FORMAT_TYPE_UINT
4: [       OK ] XeImageFormatTypeToString.ZE_IMAGE_FORMAT_TYPE_UINT (0 ms)
4: [ RUN      ] XeImageFormatTypeToString.ZE_IMAGE_FORMAT_TYPE_SINT
4: [       OK ] XeImageFormatTypeToString.ZE_IMAGE_FORMAT_TYPE_SINT (0 ms)
4: [ RUN      ] XeImageFormatTypeToString.ZE_IMAGE_FORMAT_TYPE_UNORM
4: [       OK ] XeImageFormatTypeToString.ZE_IMAGE_FORMAT_TYPE_UNORM (0 ms)
4: [ RUN      ] XeImageFormatTypeToString.ZE_IMAGE_FORMAT_TYPE_SNORM
4: [       OK ] XeImageFormatTypeToString.ZE_IMAGE_FORMAT_TYPE_SNORM (0 ms)
4: [ RUN      ] XeImageFormatTypeToString.ZE_IMAGE_FORMAT_TYPE_FLOAT
4: [       OK ] XeImageFormatTypeToString.ZE_IMAGE_FORMAT_TYPE_FLOAT (0 ms)
4: [ RUN      ] XeImageFormatTypeToString.InvalidValue
4: [       OK ] XeImageFormatTypeToString.InvalidValue (0 ms)
4: [----------] 6 tests from XeImageFormatTypeToString (0 ms total)
4: 
4: [----------] 8 tests from XeImageFormatSwizzleToString
4: [ RUN      ] XeImageFormatSwizzleToString.ZE_IMAGE_FORMAT_SWIZZLE_R
4: [       OK ] XeImageFormatSwizzleToString.ZE_IMAGE_FORMAT_SWIZZLE_R (0 ms)
4: [ RUN      ] XeImageFormatSwizzleToString.ZE_IMAGE_FORMAT_SWIZZLE_G
4: [       OK ] XeImageFormatSwizzleToString.ZE_IMAGE_FORMAT_SWIZZLE_G (0 ms)
4: [ RUN      ] XeImageFormatSwizzleToString.ZE_IMAGE_FORMAT_SWIZZLE_B
4: [       OK ] XeImageFormatSwizzleToString.ZE_IMAGE_FORMAT_SWIZZLE_B (0 ms)
4: [ RUN      ] XeImageFormatSwizzleToString.ZE_IMAGE_FORMAT_SWIZZLE_A
4: [       OK ] XeImageFormatSwizzleToString.ZE_IMAGE_FORMAT_SWIZZLE_A (0 ms)
4: [ RUN      ] XeImageFormatSwizzleToString.ZE_IMAGE_FORMAT_SWIZZLE_0
4: [       OK ] XeImageFormatSwizzleToString.ZE_IMAGE_FORMAT_SWIZZLE_0 (0 ms)
4: [ RUN      ] XeImageFormatSwizzleToString.ZE_IMAGE_FORMAT_SWIZZLE_1
4: [       OK ] XeImageFormatSwizzleToString.ZE_IMAGE_FORMAT_SWIZZLE_1 (0 ms)
4: [ RUN      ] XeImageFormatSwizzleToString.ZE_IMAGE_FORMAT_SWIZZLE_X
4: [       OK ] XeImageFormatSwizzleToString.ZE_IMAGE_FORMAT_SWIZZLE_X (0 ms)
4: [ RUN      ] XeImageFormatSwizzleToString.InvalidValue
4: [       OK ] XeImageFormatSwizzleToString.InvalidValue (0 ms)
4: [----------] 8 tests from XeImageFormatSwizzleToString (0 ms total)
4: 
4: [----------] 11 tests from XeImageFlagToString
4: [ RUN      ] XeImageFlagToString.ZE_IMAGE_FLAG_PROGRAM_READ
4: [       OK ] XeImageFlagToString.ZE_IMAGE_FLAG_PROGRAM_READ (0 ms)
4: [ RUN      ] XeImageFlagToString.ZE_IMAGE_FLAG_PROGRAM_WRITE
4: [       OK ] XeImageFlagToString.ZE_IMAGE_FLAG_PROGRAM_WRITE (0 ms)
4: [ RUN      ] XeImageFlagToString.ZE_IMAGE_FLAG_BIAS_CACHED
4: [       OK ] XeImageFlagToString.ZE_IMAGE_FLAG_BIAS_CACHED (0 ms)
4: [ RUN      ] XeImageFlagToString.ZE_IMAGE_FLAG_BIAS_UNCACHED
4: [       OK ] XeImageFlagToString.ZE_IMAGE_FLAG_BIAS_UNCACHED (0 ms)
4: [ RUN      ] XeImageFlagToString.ZE_IMAGE_FLAG_PROGRAM_READ_WRITE
4: [       OK ] XeImageFlagToString.ZE_IMAGE_FLAG_PROGRAM_READ_WRITE (0 ms)
4: [ RUN      ] XeImageFlagToString.ZE_IMAGE_FLAG_PROGRAM_READ_CACHED
4: [       OK ] XeImageFlagToString.ZE_IMAGE_FLAG_PROGRAM_READ_CACHED (0 ms)
4: [ RUN      ] XeImageFlagToString.ZE_IMAGE_FLAG_PROGRAM_READ_UNCACHED
4: [       OK ] XeImageFlagToString.ZE_IMAGE_FLAG_PROGRAM_READ_UNCACHED (0 ms)
4: [ RUN      ] XeImageFlagToString.ZE_IMAGE_FLAG_PROGRAM_WRITE_CACHED
4: [       OK ] XeImageFlagToString.ZE_IMAGE_FLAG_PROGRAM_WRITE_CACHED (0 ms)
4: [ RUN      ] XeImageFlagToString.ZE_IMAGE_FLAG_PROGRAM_WRITE_UNCACHED
4: [       OK ] XeImageFlagToString.ZE_IMAGE_FLAG_PROGRAM_WRITE_UNCACHED (0 ms)
4: [ RUN      ] XeImageFlagToString.ZE_IMAGE_FLAG_PROGRAM_READ_WRITE_CACHED
4: [       OK ] XeImageFlagToString.ZE_IMAGE_FLAG_PROGRAM_READ_WRITE_CACHED (0 ms)
4: [ RUN      ] XeImageFlagToString.ZE_IMAGE_FLAG_PROGRAM_READ_WRITE_UNCACHED
4: [       OK ] XeImageFlagToString.ZE_IMAGE_FLAG_PROGRAM_READ_WRITE_UNCACHED (0 ms)
4: [----------] 11 tests from XeImageFlagToString (0 ms total)
4: 
4: [----------] 6 tests from XeImageTypeToString
4: [ RUN      ] XeImageTypeToString.ZE_IMAGE_TYPE_1D
4: [       OK ] XeImageTypeToString.ZE_IMAGE_TYPE_1D (0 ms)
4: [ RUN      ] XeImageTypeToString.ZE_IMAGE_TYPE_2D
4: [       OK ] XeImageTypeToString.ZE_IMAGE_TYPE_2D (0 ms)
4: [ RUN      ] XeImageTypeToString.ZE_IMAGE_TYPE_3D
4: [       OK ] XeImageTypeToString.ZE_IMAGE_TYPE_3D (0 ms)
4: [ RUN      ] XeImageTypeToString.ZE_IMAGE_TYPE_1DARRAY
4: [       OK ] XeImageTypeToString.ZE_IMAGE_TYPE_1DARRAY (0 ms)
4: [ RUN      ] XeImageTypeToString.ZE_IMAGE_TYPE_2DARRAY
4: [       OK ] XeImageTypeToString.ZE_IMAGE_TYPE_2DARRAY (0 ms)
4: [ RUN      ] XeImageTypeToString.InvalidValue
4: [       OK ] XeImageTypeToString.InvalidValue (0 ms)
4: [----------] 6 tests from XeImageTypeToString (0 ms total)
4: 
4: [----------] 2 tests from LoadBinaryFile
4: [ RUN      ] LoadBinaryFile.ValidFile
4: [2020-04-07 19:05:51] [error] Failed to load binary file: binary_file.binerror No such file or directory
4: utils/utils/test/utils_integration_tests.cpp:17: Failure
4: Expected equality of these values:
4:   reference
4:     Which is: { '\0', '\x11' (17), '"' (34, 0x22), '3' (51, 0x33) }
4:   bytes
4:     Which is: {}
4: [  FAILED  ] LoadBinaryFile.ValidFile (0 ms)
4: [ RUN      ] LoadBinaryFile.NotExistingFile
4: [2020-04-07 19:05:51] [error] Failed to load binary file: invalid/patherror No such file or directory
4: [       OK ] LoadBinaryFile.NotExistingFile (0 ms)
4: [----------] 2 tests from LoadBinaryFile (0 ms total)
4: 
4: [----------] 1 test from SaveBinaryFile
4: [ RUN      ] SaveBinaryFile.ValidFile
4: [       OK ] SaveBinaryFile.ValidFile (0 ms)
4: [----------] 1 test from SaveBinaryFile (0 ms total)
4: 
4: [----------] Global test environment tear-down
4: [==========] 116 tests from 24 test cases ran. (1 ms total)
4: [  PASSED  ] 113 tests.
4: [  FAILED  ] 3 tests, listed below:
4: [  FAILED  ] XeApiVersionToString.ZE_API_VERSION_1_0
4: [  FAILED  ] XeResultToString.ZE_RESULT_ERROR_INVALID_ARGUMENT
4: [  FAILED  ] LoadBinaryFile.ValidFile
4: 
4:  3 FAILED TESTS
4/4 Test #4: utils_tests ......................***Failed    0.01 sec

75% tests passed, 1 tests failed out of 4

Total Test time (real) =   0.02 sec

The following tests FAILED:
	  4 - utils_tests (Failed)
```
</details>
