### PR TITLE
Fix `test_multi_device_multi_process` 

### DIFF
--- a/conformance_tests/core/test_multiprocess/src/test_process_helper.cpp
+++ b/conformance_tests/core/test_multiprocess/src/test_process_helper.cpp
@@ -28,7 +28,7 @@ int main(int argc, char **argv) {
   auto command_list = lzt::create_command_list(device);
   auto command_queue = lzt::create_command_queue(device);
 
-  auto module = lzt::create_module(devices[0], "multi_process_add.spv");
+  auto module = lzt::create_module(device, "multi_process_add.spv");
   auto kernel = lzt::create_function(module, "add_two_arrays");
 
   auto constexpr memory_size = 8192;


### PR DESCRIPTION
Hi,

In `test_process_helper.cpp` the module was always created with the `device[0]` where the memory allocation, and command list use their "local" device (`proc_number % devices.size()`). 

This caused the test to fail in multi-GPU node. This PR fixes this issue, but using the "local" device everywhere


