### PR TITLE
Apply advice with system memory preferred location

### DIFF
--- a/perf_tests/ze_peak/src/transfer_bw.cpp
+++ b/perf_tests/ze_peak/src/transfer_bw.cpp
@@ -89,6 +89,20 @@ long double ZePeak::_transfer_bw_host_copy(L0Context &context,
                                  &temp_cmd_list);
   }
 
+  /*
+    Apply memory advise with preferred location set to system memory
+    to ensure best placement for kmd-migrated shared allocations (only).
+  */
+  if (shared_is_dest) {
+    zeCommandListAppendMemAdvise(
+      temp_cmd_list, context.device, destination_buffer, buffer_size,
+      ZE_MEMORY_ADVICE_SET_SYSTEM_MEMORY_PREFERRED_LOCATION);
+  } else {
+    zeCommandListAppendMemAdvise(
+        temp_cmd_list, context.device, source_buffer, buffer_size,
+        ZE_MEMORY_ADVICE_SET_SYSTEM_MEMORY_PREFERRED_LOCATION);
+  }
+
   for (uint32_t i = 0; i < warmup_iterations; i++) {
     /*
 


### PR DESCRIPTION
Improves performance in System Memory Copy To/From Shared Memory tests
by ensuring best memory placement for kmd-migrated shared allocations.

Related-To: NEO-7851

Signed-off-by: Slawomir Milczarek <slawomir.milczarek@intel.com>