### PR TITLE
[api_ltracing_dynamic] Fix memory not allocated in AppendImageCopyFromMemoryExt test

### DIFF
--- a/layer_tests/tracing/src/test_api_ltracing_compat.cpp
+++ b/layer_tests/tracing/src/test_api_ltracing_compat.cpp
@@ -1878,6 +1878,7 @@ TEST_F(
   }
 
   init_command_list();
+  init_memory();
   if (!init_image()) {
     LOG_WARNING << "test not executed because "
                    "images are not supported";


### PR DESCRIPTION
The test expects that zeCommandListAppendImageCopyFromMemoryExt returns ZE_SUCCESS, so the `memory` on host must be allocated.