### PR TITLE
fix: Resolve nullptr access issues

### DIFF
--- a/conformance_tests/sysman/test_sysman_device/src/test_sysman_device.cpp
+++ b/conformance_tests/sysman/test_sysman_device/src/test_sysman_device.cpp
@@ -113,12 +113,14 @@ TEST_F(
     GivenHierarchyModeCombindedAndSysmanEnableEnvDisabledThenUUIDFromCoreAndSysmanMatches) {
   auto is_sysman_enabled = getenv("ZES_ENABLE_SYSMAN");
   // Disabling enable_sysman env if it's defaultly enabled
-  if (strcmp(is_sysman_enabled, "1") == 0) {
-    putenv("ZES_ENABLE_SYSMAN=0");
+  if (is_sysman_enabled != nullptr && strcmp(is_sysman_enabled, "1") == 0) {
+    char disable_sysman_env[] = "ZES_ENABLE_SYSMAN=0";
+    putenv(disable_sysman_env);
   }
   run_child_process("COMBINED");
-  if (strcmp(is_sysman_enabled, "1") == 0) {
-    putenv("ZES_ENABLE_SYSMAN=1");
+  if (is_sysman_enabled != nullptr && strcmp(is_sysman_enabled, "1") == 0) {
+    char enable_sysman_env[] = "ZES_ENABLE_SYSMAN=1";
+    putenv(enable_sysman_env);
   }
 }
 
@@ -127,12 +129,14 @@ TEST_F(
     GivenHierarchyModeCompositeAndSysmanEnableEnvDisabledThenUUIDFromCoreAndSysmanMatches) {
   auto is_sysman_enabled = getenv("ZES_ENABLE_SYSMAN");
   // Disabling enable_sysman env if it's defaultly enabled
-  if (strcmp(is_sysman_enabled, "1") == 0) {
-    putenv("ZES_ENABLE_SYSMAN=0");
+  if (is_sysman_enabled != nullptr && strcmp(is_sysman_enabled, "1") == 0) {
+    char disable_sysman_env[] = "ZES_ENABLE_SYSMAN=0";
+    putenv(disable_sysman_env);
   }
   run_child_process("COMPOSITE");
-  if (strcmp(is_sysman_enabled, "1") == 0) {
-    putenv("ZES_ENABLE_SYSMAN=1");
+  if (is_sysman_enabled != nullptr && strcmp(is_sysman_enabled, "1") == 0) {
+    char enable_sysman_env[] = "ZES_ENABLE_SYSMAN=1";
+    putenv(enable_sysman_env);
   }
 }
 #endif // USE_ZESINIT

--- a/conformance_tests/sysman/test_sysman_init/src/test_init.cpp
+++ b/conformance_tests/sysman/test_sysman_init/src/test_init.cpp
@@ -23,8 +23,9 @@ TEST(
     GivenSysmanEnableEnvDisabledAndCoreInitializedFirstWhenSysmanInitializedThenzesDriverGetWorks) {
   auto is_sysman_enabled = getenv("ZES_ENABLE_SYSMAN");
   // Disabling enable_sysman env if it's defaultly enabled
-  if (strcmp(is_sysman_enabled, "1") == 0) {
-    putenv("ZES_ENABLE_SYSMAN=0");
+  if (is_sysman_enabled != nullptr && strcmp(is_sysman_enabled, "1") == 0) {
+    char disable_sysman_env[] = "ZES_ENABLE_SYSMAN=0";
+    putenv(disable_sysman_env);
   }
   ASSERT_EQ(ZE_RESULT_SUCCESS, zeInit(0));
   uint32_t zeInitCount = 0;
@@ -34,8 +35,9 @@ TEST(
   uint32_t zesInitCount = 0;
   ASSERT_EQ(ZE_RESULT_SUCCESS, zesDriverGet(&zesInitCount, nullptr));
   ASSERT_GT(zesInitCount, 0);
-  if (strcmp(is_sysman_enabled, "1") == 0) {
-    putenv("ZES_ENABLE_SYSMAN=1");
+  if (is_sysman_enabled != nullptr && strcmp(is_sysman_enabled, "1") == 0) {
+    char enable_sysman_env[] = "ZES_ENABLE_SYSMAN=1";
+    putenv(enable_sysman_env);
   }
 }
 


### PR DESCRIPTION
* Add nullptr check for returns form getenv to avoid sigsegv.
* Passing char[] for putenv instead of string constant to avoid compilation warning.

Related-To: VLCLJ-2228