### PR TITLE
Add CTS for Sysmandevicemapping to verify UUID's

### DIFF
--- a/conformance_tests/sysman/test_sysman_device/src/test_sysman_device.cpp
+++ b/conformance_tests/sysman/test_sysman_device/src/test_sysman_device.cpp
@@ -135,6 +135,22 @@ TEST_F(
     putenv("ZES_ENABLE_SYSMAN=1");
   }
 }
+
+TEST_F(
+    SYSMAN_DEVICE_TEST,
+    GivenHierarchyModeFlatAndSysmanEnableEnvDisabledThenUUIDFromCoreAndSysmanMatches) {
+  auto is_sysman_enabled = getenv("ZES_ENABLE_SYSMAN");
+  // Disabling enable_sysman env if it's defaultly enabled
+  if (is_sysman_enabled != nullptr && strcmp(is_sysman_enabled, "1") == 0) {
+    char disable_sysman_env[] = "ZES_ENABLE_SYSMAN=0";
+    putenv(disable_sysman_env);
+  }
+  run_child_process("FLAT");
+  if (is_sysman_enabled != nullptr && strcmp(is_sysman_enabled, "1") == 0) {
+    char enable_sysman_env[] = "ZES_ENABLE_SYSMAN=1";
+    putenv(enable_sysman_env);
+  }
+}
 #endif // USE_ZESINIT
 
 TEST_F(

--- a/conformance_tests/sysman/test_sysman_device/src/test_sysman_device_helper.cpp
+++ b/conformance_tests/sysman/test_sysman_device/src/test_sysman_device_helper.cpp
@@ -99,28 +99,22 @@ int main(int argc, char **argv) {
   auto sysman_devices = lzt::get_zes_devices();
   EXPECT_FALSE(sysman_devices.empty());
 
-  if (strcmp(device_hierarchy, "FLAT") != 0) { // composite or combined mode
-    std::vector<UUID> sysman_device_uuids;
-    std::vector<UUID> ze_root_uuids;
+  std::vector<UUID> sysman_device_uuids{};
+  std::vector<UUID> ze_device_uuids{};
 
+  if (strcmp(device_hierarchy, "FLAT") != 0) { // composite or combined mode
     for (const auto &sysman_device : sysman_devices) {
       sysman_device_uuids.push_back(get_sysman_device_uuid(sysman_device));
     }
 
     for (const auto &ze_device : ze_devices) {
       auto ze_root_uuid = get_ze_root_uuid(ze_device, device_hierarchy);
-      if (std::find(ze_root_uuids.begin(), ze_root_uuids.end(), ze_root_uuid) ==
-          ze_root_uuids.end()) {
-        ze_root_uuids.push_back(ze_root_uuid);
+      if (std::find(ze_device_uuids.begin(), ze_device_uuids.end(),
+                    ze_root_uuid) == ze_device_uuids.end()) {
+        ze_device_uuids.push_back(ze_root_uuid);
       }
     }
-
-    EXPECT_TRUE(
-        compare_core_and_sysman_uuid(ze_root_uuids, sysman_device_uuids));
   } else { // flat mode
-    std::vector<UUID> sysman_device_uuids;
-    std::vector<UUID> ze_device_uuids;
-
     for (const auto &sysman_device : sysman_devices) {
       auto device_properties = lzt::get_sysman_device_properties(sysman_device);
       uint32_t sub_devices_count = device_properties.numSubdevices;
@@ -136,10 +130,10 @@ int main(int argc, char **argv) {
     for (const auto &ze_device : ze_devices) {
       ze_device_uuids.push_back(get_ze_device_uuid(ze_device));
     }
-
-    EXPECT_TRUE(
-        compare_core_and_sysman_uuid(ze_device_uuids, sysman_device_uuids));
   }
+
+  EXPECT_TRUE(
+      compare_core_and_sysman_uuid(ze_device_uuids, sysman_device_uuids));
 
   exit(0);
 }

--- a/conformance_tests/sysman/test_sysman_device/src/test_sysman_device_helper.cpp
+++ b/conformance_tests/sysman/test_sysman_device/src/test_sysman_device_helper.cpp
@@ -12,7 +12,7 @@
 
 namespace lzt = level_zero_tests;
 
-#define UUID std::array<uint8_t, ZE_MAX_DEVICE_UUID_SIZE>
+typedef std::array<uint8_t, ZE_MAX_DEVICE_UUID_SIZE> UUID;
 
 #define TO_STD_ARRAY(x)                                                        \
   [](const uint8_t(&arr)[ZE_MAX_DEVICE_UUID_SIZE]) {                           \
@@ -95,8 +95,7 @@ void get_ze_root_uuids(std::vector<ze_device_handle_t> ze_devices,
 }
 
 void get_ze_device_uuids(std::vector<ze_device_handle_t> ze_devices,
-                         std::vector<UUID> &ze_device_uuids,
-                         char *device_hierarchy) {
+                         std::vector<UUID> &ze_device_uuids) {
   for (const auto &ze_device : ze_devices) {
     auto ze_device_properties = lzt::get_device_properties(ze_device);
     auto ze_device_uuid = ze_device_properties.uuid;
@@ -147,7 +146,7 @@ int main(int argc, char **argv) {
     std::vector<UUID> sysman_sub_device_uuids;
     get_sysman_sub_devices_uuids(sysman_devices, sysman_sub_device_uuids);
     std::vector<UUID> ze_device_uuids;
-    get_ze_device_uuids(ze_devices, ze_device_uuids, device_hierarchy);
+    get_ze_device_uuids(ze_devices, ze_device_uuids);
 
     compare_core_and_sysman_uuid(ze_device_uuids, sysman_sub_device_uuids);
   }


### PR DESCRIPTION
  *  zesDeviceGetSubDevicePropertiesExp is used to retrieve Subdevice UUID's.
  * Sysman UUID's are compared with Core UUID's (FLAT Mode)

Related-To: VLCLJ-2256