### PR TITLE
Update Alternating Interrupt/Resume Test

### DIFF
--- a/conformance_tests/tools/debug/src/test_debug.cpp
+++ b/conformance_tests/tools/debug/src/test_debug.cpp
@@ -1440,6 +1440,7 @@ void zetDebugThreadControlTest::SetUpThreadControl(ze_device_handle_t &device,
             smaller_thread_functor());
 }
 
+#define INTERRUPT_TEST_SLEEP std::chrono::seconds(2)
 void zetDebugThreadControlTest::run_alternate_stop_resume_test(
     std::vector<ze_device_handle_t> &devices, bool use_sub_devices) {
   for (auto &device : devices) {
@@ -1467,7 +1468,7 @@ void zetDebugThreadControlTest::run_alternate_stop_resume_test(
       }
       i++;
     }
-    std::this_thread::sleep_for(std::chrono::seconds(2));
+    std::this_thread::sleep_for(INTERRUPT_TEST_SLEEP);
 
     LOG_INFO
         << "[Debugger] ######### Interrupting Odd AND resumming Even threads "
@@ -1494,7 +1495,7 @@ void zetDebugThreadControlTest::run_alternate_stop_resume_test(
       }
       i++;
     }
-    std::this_thread::sleep_for(std::chrono::seconds(2));
+    std::this_thread::sleep_for(INTERRUPT_TEST_SLEEP);
 
     LOG_INFO
         << "[Debugger] ######### Interrupting Even threads AND resumming Odd "
@@ -1521,7 +1522,7 @@ void zetDebugThreadControlTest::run_alternate_stop_resume_test(
       }
       i++;
     }
-    std::this_thread::sleep_for(std::chrono::seconds(2));
+    std::this_thread::sleep_for(INTERRUPT_TEST_SLEEP);
 
     LOG_INFO << "[Debugger] ######### Interrupting Odd threads ##########";
     threadsToCheck.clear();
@@ -1559,7 +1560,7 @@ void zetDebugThreadControlTest::run_alternate_stop_resume_test(
       i++;
     }
 
-    std::this_thread::sleep_for(std::chrono::seconds(2));
+    std::this_thread::sleep_for(INTERRUPT_TEST_SLEEP);
     EXPECT_EQ(debugHelper.running(), true);
 
     LOG_INFO << "[Debugger] ######### Ressuming Odd threads ##########";
@@ -1573,7 +1574,7 @@ void zetDebugThreadControlTest::run_alternate_stop_resume_test(
     }
 
     LOG_INFO << "[Debugger] ######### Checking ALL threads are running ######";
-    std::this_thread::sleep_for(std::chrono::seconds(2));
+    std::this_thread::sleep_for(INTERRUPT_TEST_SLEEP);
     stoppedThreadsCheck.clear();
     stoppedThreadsCheck = get_stopped_threads(debugSession, device);
     EXPECT_EQ(stoppedThreadsCheck.size(), 0);
@@ -1608,7 +1609,7 @@ void zetDebugThreadControlTest::run_alternate_stop_resume_test(
 
     LOG_INFO
         << "[Debugger] ######### Checking ALL threads are running ##########";
-    std::this_thread::sleep_for(std::chrono::seconds(2));
+    std::this_thread::sleep_for(INTERRUPT_TEST_SLEEP);
     stoppedThreadsCheck.clear();
     stoppedThreadsCheck = get_stopped_threads(debugSession, device);
     EXPECT_EQ(stoppedThreadsCheck.size(), 0);

--- a/utils/test_harness/tools/include/test_harness_debug.hpp
+++ b/utils/test_harness/tools/include/test_harness_debug.hpp
@@ -37,14 +37,15 @@ void debug_ack_event(const zet_debug_session_handle_t &debug_session,
                      const zet_debug_event_t *debug_event);
 
 void debug_interrupt(const zet_debug_session_handle_t &debug_session,
-                     const ze_device_thread_t &device_thread);
+                     const ze_device_thread_t &device_thread,
+                     bool retry = false);
 
 void debug_resume(const zet_debug_session_handle_t &debug_session,
                   const ze_device_thread_t &device_thread);
 
 void clear_exceptions(const ze_device_handle_t &device,
-                    const zet_debug_session_handle_t &debug_session,
-                  const ze_device_thread_t &device_thread);
+                      const zet_debug_session_handle_t &debug_session,
+                      const ze_device_thread_t &device_thread);
 
 void debug_read_memory(const zet_debug_session_handle_t &debug_session,
                        const ze_device_thread_t &device_thread,

--- a/utils/test_harness/tools/src/test_harness_debug.cpp
+++ b/utils/test_harness/tools/src/test_harness_debug.cpp
@@ -131,9 +131,21 @@ void debug_ack_event(const zet_debug_session_handle_t &debug_session,
 }
 
 void debug_interrupt(const zet_debug_session_handle_t &debug_session,
-                     const ze_device_thread_t &device_thread) {
+                     const ze_device_thread_t &device_thread, bool retry) {
 
-  EXPECT_EQ(ZE_RESULT_SUCCESS, zetDebugInterrupt(debug_session, device_thread));
+  if (!retry) {
+    EXPECT_EQ(ZE_RESULT_SUCCESS,
+              zetDebugInterrupt(debug_session, device_thread));
+  } else {
+    auto result = zetDebugInterrupt(debug_session, device_thread);
+    if (result != ZE_RESULT_SUCCESS) {
+      LOG_WARNING << "[Debugger] Interrupt failed: " << result
+                  << " SLICE:" << device_thread.slice
+                  << " SUBSLICE: " << device_thread.subslice
+                  << " EU: " << device_thread.eu
+                  << " THREAD: " << device_thread.thread;
+    }
+  }
 }
 
 void debug_resume(const zet_debug_session_handle_t &debug_session,
@@ -181,8 +193,8 @@ bool get_register_set_props(ze_device_handle_t device,
 }
 
 void clear_exceptions(const ze_device_handle_t &device,
-                    const zet_debug_session_handle_t &debug_session,
-                  const ze_device_thread_t &device_thread) {
+                      const zet_debug_session_handle_t &debug_session,
+                      const ze_device_thread_t &device_thread) {
   size_t reg_size_in_bytes = 0;
 
   zet_debug_regset_properties_t cr_reg_prop;


### PR DESCRIPTION
Updates the test to retry interrupting threads
in case the threads were unavailable/not resumed
when initial interrupt request sent