### PR TITLE
Fix GivenCallToZeInitDriversWithNullPointerCountThenExpectFailure

### DIFF
--- a/negative_tests/core/test_driver_errors/src/test_driver_errors.cpp
+++ b/negative_tests/core/test_driver_errors/src/test_driver_errors.cpp
@@ -58,7 +58,12 @@ TEST(
   desc.pNext = nullptr;
 
   // Test with nullptr pCount
-  desc.flags = 0;
+  desc.flags = UINT32_MAX;
+  // Check for multiple errors depending on if this is the first call to zeInitDrivers.
+  auto result = zeInitDrivers(nullptr, nullptr, &desc);
+  EXPECT_TRUE(result == ZE_RESULT_ERROR_INVALID_ARGUMENT ||
+              result == ZE_RESULT_ERROR_INVALID_ENUMERATION || ZE_RESULT_ERROR_INVALID_NULL_POINTER);
+  // The second call will be deterministically ZE_RESULT_ERROR_INVALID_NULL_POINTER
   EXPECT_EQ(ZE_RESULT_ERROR_INVALID_NULL_POINTER, zeInitDrivers(nullptr, nullptr, &desc));
 }
 


### PR DESCRIPTION
-Fixed GivenCallToZeInitDriversWithNullPointerCountThenExpectFailure to correctly check for the range of error results depending on if the test was called with the init being the first call or a new call.