### PR TITLE
fix: Removed the condition variable check from Sysman Memory CTS

### DIFF
--- a/conformance_tests/sysman/test_sysman_memory/src/test_sysman_memory.cpp
+++ b/conformance_tests/sysman/test_sysman_memory/src/test_sysman_memory.cpp
@@ -10,6 +10,7 @@
 #include "logging/logging.hpp"
 #include "utils/utils.hpp"
 #include "test_harness/test_harness.hpp"
+#include <condition_variable>
 #include <thread>
 
 namespace lzt = level_zero_tests;

--- a/conformance_tests/sysman/test_sysman_memory/src/test_sysman_memory.cpp
+++ b/conformance_tests/sysman/test_sysman_memory/src/test_sysman_memory.cpp
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2020-2023 Intel Corporation
+ * Copyright (C) 2020-2025 Intel Corporation
  *
  * SPDX-License-Identifier: MIT
  *
@@ -17,8 +17,6 @@ namespace lzt = level_zero_tests;
 #include <level_zero/zes_api.h>
 
 namespace {
-
-std::mutex mem_mutex;
 
 #ifdef USE_ZESINIT
 class MemoryModuleZesTest : public lzt::ZesSysmanCtsClass {};
@@ -401,12 +399,10 @@ void getMemoryState(ze_device_handle_t device) {
     FAIL() << "No handles found: "
            << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
-  std::unique_lock<std::mutex> lock(mem_mutex);
   for (auto mem_handle : mem_handles) {
     ASSERT_NE(nullptr, mem_handle);
     lzt::get_mem_state(mem_handle);
   }
-  lock.unlock();
 }
 
 void getRasState(ze_device_handle_t device) {
@@ -417,13 +413,11 @@ void getRasState(ze_device_handle_t device) {
     FAIL() << "No handles found: "
            << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
-  std::unique_lock<std::mutex> lock(mem_mutex);
   for (auto ras_handle : ras_handles) {
     ASSERT_NE(nullptr, ras_handle);
     ze_bool_t clear = 0;
     lzt::get_ras_state(ras_handle, clear);
   }
-  lock.unlock();
 }
 
 TEST_F(


### PR DESCRIPTION
During the call to fetch the memory and the RAS states, the condition variable check has been removed.

Related-To: VLCLJ-2343

Signed-off-by: Pratik Bari <pratik.bari@intel.com>