### PR TITLE
Fix to Boolean result check in negative test

### DIFF
--- a/negative_tests/core/test_driver_errors/src/test_driver_errors.cpp
+++ b/negative_tests/core/test_driver_errors/src/test_driver_errors.cpp
@@ -62,7 +62,7 @@ TEST(
   // Check for multiple errors depending on if this is the first call to zeInitDrivers.
   auto result = zeInitDrivers(nullptr, nullptr, &desc);
   EXPECT_TRUE(result == ZE_RESULT_ERROR_INVALID_ARGUMENT ||
-              result == ZE_RESULT_ERROR_INVALID_ENUMERATION || ZE_RESULT_ERROR_INVALID_NULL_POINTER);
+              result == ZE_RESULT_ERROR_INVALID_ENUMERATION || result == ZE_RESULT_ERROR_INVALID_NULL_POINTER);
   // The second call will be deterministically ZE_RESULT_ERROR_INVALID_NULL_POINTER
   EXPECT_EQ(ZE_RESULT_ERROR_INVALID_NULL_POINTER, zeInitDrivers(nullptr, nullptr, &desc));
 }


### PR DESCRIPTION
- Fixed result check in GivenCallToZeInitDriversWithNullPointerCountThenExpectFailure to check for the boolean value for result ==
ZE_RESULT_ERROR_INVALID_NULL_POINTER