### PR TITLE
Fix: Add Test for Validating ECC Default State Values

### DIFF
--- a/conformance_tests/sysman/test_sysman_ecc/src/test_sysman_ecc.cpp
+++ b/conformance_tests/sysman/test_sysman_ecc/src/test_sysman_ecc.cpp
@@ -185,4 +185,26 @@ TEST_F(
   }
 }
 
+TEST_F(
+    ECC_TEST,
+    GIvenValidDeviceHandleWhenEccGetDefaultStateIsQueriedThenValidValuesAreReturned) {
+  for (const auto &device : devices) {
+    auto available = lzt::get_ecc_available(device);
+    auto configurable = lzt::get_ecc_configurable(device);
+    if (available == static_cast<ze_bool_t>(true) && configurable == static_cast<ze_bool_t>(true)) {
+      zes_device_ecc_properties_t eccState = {
+          ZES_STRUCTURE_TYPE_DEVICE_ECC_PROPERTIES, nullptr};
+      EXPECT_EQ(ZE_RESULT_SUCCESS, zesDeviceGetEccState(device, &eccState));
+      EXPECT_GE(eccState.currentState, ZES_DEVICE_ECC_STATE_UNAVAILABLE);
+      EXPECT_LE(eccState.currentState, ZES_DEVICE_ECC_STATE_DISABLED);
+      EXPECT_GE(eccState.pendingState, ZES_DEVICE_ECC_STATE_UNAVAILABLE);
+      EXPECT_LE(eccState.pendingState, ZES_DEVICE_ECC_STATE_DISABLED);
+      EXPECT_GE(eccState.pendingAction, ZES_DEVICE_ACTION_NONE);
+      EXPECT_LE(eccState.pendingAction, ZES_DEVICE_ACTION_COLD_SYSTEM_REBOOT);
+    } else {
+      LOG_INFO << "ECC is not available or not configurable";
+   }
+ }
+}
+
 } // namespace


### PR DESCRIPTION
The test ensures that the ECC state retrieval API returns valid values when ECC is available on a valid device handle

Related-To: VLCLJ-2433