### PR TITLE
Remove stype validation checks

### DIFF
--- a/negative_tests/core/test_device_errors/src/test_device_errors.cpp
+++ b/negative_tests/core/test_device_errors/src/test_device_errors.cpp
@@ -36,67 +36,68 @@ TEST(
   }
 }
 
-TEST(DeviceNegativeTests, GivenInvalidStypeWhen) {
-  auto driver = lzt::get_default_driver();
-  auto device = lzt::get_default_device(driver);
+// Temporarily disabling this test until stype and pNext validation in validation layer can be fixed.
+// TEST(DeviceNegativeTests, GivenInvalidStypeWhen) {
+//   auto driver = lzt::get_default_driver();
+//   auto device = lzt::get_default_device(driver);
 
-  ASSERT_EQ(ZE_RESULT_ERROR_INVALID_NULL_HANDLE,
-            zeDeviceGetProperties(nullptr, nullptr));
+//   ASSERT_EQ(ZE_RESULT_ERROR_INVALID_NULL_HANDLE,
+//             zeDeviceGetProperties(nullptr, nullptr));
 
-  ASSERT_EQ(ZE_RESULT_ERROR_INVALID_NULL_POINTER,
-            zeDeviceGetProperties(device, nullptr));
+//   ASSERT_EQ(ZE_RESULT_ERROR_INVALID_NULL_POINTER,
+//             zeDeviceGetProperties(device, nullptr));
 
-  ze_device_properties_t props0 = {ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES,
-                                   nullptr};
-  ASSERT_EQ(ZE_RESULT_SUCCESS, zeDeviceGetProperties(device, &props0));
+//   ze_device_properties_t props0 = {ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES,
+//                                    nullptr};
+//   ASSERT_EQ(ZE_RESULT_SUCCESS, zeDeviceGetProperties(device, &props0));
 
-  ze_device_properties_t props1 = {(ze_structure_type_t)0xaaaa, nullptr};
-  ASSERT_EQ(ZE_RESULT_ERROR_INVALID_ARGUMENT,
-            zeDeviceGetProperties(device, &props1));
+//   ze_device_properties_t props1 = {(ze_structure_type_t)0xaaaa, nullptr};
+//   ASSERT_EQ(ZE_RESULT_ERROR_INVALID_ARGUMENT,
+//             zeDeviceGetProperties(device, &props1));
 
-  props0.pNext = &props1;
-  ASSERT_EQ(ZE_RESULT_ERROR_INVALID_ARGUMENT,
-            zeDeviceGetProperties(device, &props0));
+//   props0.pNext = &props1;
+//   ASSERT_EQ(ZE_RESULT_ERROR_INVALID_ARGUMENT,
+//             zeDeviceGetProperties(device, &props0));
 
-  ze_device_properties_t props2 = {ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES_1_2,
-                                   nullptr};
-  ASSERT_EQ(ZE_RESULT_SUCCESS, zeDeviceGetProperties(device, &props2));
+//   ze_device_properties_t props2 = {ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES_1_2,
+//                                    nullptr};
+//   ASSERT_EQ(ZE_RESULT_SUCCESS, zeDeviceGetProperties(device, &props2));
 
-  props2.pNext = &props0;
-  ASSERT_EQ(ZE_RESULT_ERROR_INVALID_ARGUMENT,
-            zeDeviceGetProperties(device, &props2));
-}
+//   props2.pNext = &props0;
+//   ASSERT_EQ(ZE_RESULT_ERROR_INVALID_ARGUMENT,
+//             zeDeviceGetProperties(device, &props2));
+// }
 
-TEST(DeviceNegativeTests,
-     GivenDeviceCacheWithMultipleStypeWithInvalidStypeWhen) {
-  auto driver = lzt::get_default_driver();
-  auto device = lzt::get_default_device(driver);
+// TEST(DeviceNegativeTests,
+//      GivenDeviceCacheWithMultipleStypeWithInvalidStypeWhen) {
+//   auto driver = lzt::get_default_driver();
+//   auto device = lzt::get_default_device(driver);
 
-  uint32_t count = 0;
+//   uint32_t count = 0;
 
-  ASSERT_EQ(ZE_RESULT_ERROR_INVALID_NULL_HANDLE,
-            zeDeviceGetCacheProperties(nullptr, &count, nullptr));
+//   ASSERT_EQ(ZE_RESULT_ERROR_INVALID_NULL_HANDLE,
+//             zeDeviceGetCacheProperties(nullptr, &count, nullptr));
 
-  ASSERT_EQ(ZE_RESULT_ERROR_INVALID_NULL_POINTER,
-            zeDeviceGetCacheProperties(device, nullptr, nullptr));
+//   ASSERT_EQ(ZE_RESULT_ERROR_INVALID_NULL_POINTER,
+//             zeDeviceGetCacheProperties(device, nullptr, nullptr));
 
-  ASSERT_EQ(ZE_RESULT_SUCCESS,
-            zeDeviceGetCacheProperties(device, &count, nullptr));
+//   ASSERT_EQ(ZE_RESULT_SUCCESS,
+//             zeDeviceGetCacheProperties(device, &count, nullptr));
 
-  std::vector<ze_device_cache_properties_t> cacheProperties(count);
-  for (auto &properties : cacheProperties) {
-    properties = {ZE_STRUCTURE_TYPE_DEVICE_CACHE_PROPERTIES, nullptr};
-  }
+//   std::vector<ze_device_cache_properties_t> cacheProperties(count);
+//   for (auto &properties : cacheProperties) {
+//     properties = {ZE_STRUCTURE_TYPE_DEVICE_CACHE_PROPERTIES, nullptr};
+//   }
 
-  ASSERT_EQ(ZE_RESULT_SUCCESS,
-            zeDeviceGetCacheProperties(device, &count, cacheProperties.data()));
+//   ASSERT_EQ(ZE_RESULT_SUCCESS,
+//             zeDeviceGetCacheProperties(device, &count, cacheProperties.data()));
 
-  ze_device_cache_properties_t dummyCacheProperties = {
-      (ze_structure_type_t)0xaaaa, nullptr};
-  cacheProperties[0].pNext = &dummyCacheProperties;
+//   ze_device_cache_properties_t dummyCacheProperties = {
+//       (ze_structure_type_t)0xaaaa, nullptr};
+//   cacheProperties[0].pNext = &dummyCacheProperties;
 
-  ASSERT_EQ(ZE_RESULT_ERROR_INVALID_ARGUMENT,
-            zeDeviceGetCacheProperties(device, &count, cacheProperties.data()));
-}
+//   ASSERT_EQ(ZE_RESULT_ERROR_INVALID_ARGUMENT,
+//             zeDeviceGetCacheProperties(device, &count, cacheProperties.data()));
+// }
 
 } // namespace

--- a/negative_tests/sysman/test_device_errors/src/test_zesdevice_errors.cpp
+++ b/negative_tests/sysman/test_device_errors/src/test_zesdevice_errors.cpp
@@ -19,30 +19,30 @@ namespace lzt = level_zero_tests;
 
 namespace {
 
-TEST(
-    MetricNegativeTests,
-    GivenZesDevicePropertiesWithInvalidParametersThenGetParameterValidationErrorReturns) {
+// TEST(
+//     MetricNegativeTests,
+//     GivenZesDevicePropertiesWithInvalidParametersThenGetParameterValidationErrorReturns) {
 
-  auto driver = lzt::get_default_driver();
-  auto device = lzt::get_default_device(driver);
+//   auto driver = lzt::get_default_driver();
+//   auto device = lzt::get_default_device(driver);
 
-  zes_device_properties_t deviceProperties0 = {
-      ZES_STRUCTURE_TYPE_DEVICE_PROPERTIES, nullptr};
-  zes_device_properties_t deviceProperties1 = {(zes_structure_type_t)0xaaaa,
-                                               nullptr};
+//   zes_device_properties_t deviceProperties0 = {
+//       ZES_STRUCTURE_TYPE_DEVICE_PROPERTIES, nullptr};
+//   zes_device_properties_t deviceProperties1 = {(zes_structure_type_t)0xaaaa,
+//                                                nullptr};
 
-  ASSERT_EQ(ZE_RESULT_ERROR_INVALID_NULL_HANDLE,
-            zesDeviceGetProperties(nullptr, &deviceProperties0));
+//   ASSERT_EQ(ZE_RESULT_ERROR_INVALID_NULL_HANDLE,
+//             zesDeviceGetProperties(nullptr, &deviceProperties0));
 
-  ASSERT_EQ(ZE_RESULT_ERROR_INVALID_NULL_POINTER,
-            zesDeviceGetProperties(device, nullptr));
+//   ASSERT_EQ(ZE_RESULT_ERROR_INVALID_NULL_POINTER,
+//             zesDeviceGetProperties(device, nullptr));
 
-  ASSERT_EQ(ZE_RESULT_ERROR_INVALID_ARGUMENT,
-            zesDeviceGetProperties(device, &deviceProperties1));
+//   ASSERT_EQ(ZE_RESULT_ERROR_INVALID_ARGUMENT,
+//             zesDeviceGetProperties(device, &deviceProperties1));
 
-  deviceProperties0.pNext = &deviceProperties1;
-  ASSERT_EQ(ZE_RESULT_ERROR_INVALID_ARGUMENT,
-            zesDeviceGetProperties(device, &deviceProperties0));
-}
+//   deviceProperties0.pNext = &deviceProperties1;
+//   ASSERT_EQ(ZE_RESULT_ERROR_INVALID_ARGUMENT,
+//             zesDeviceGetProperties(device, &deviceProperties0));
+// }
 
 } // namespace

--- a/negative_tests/tools/metric_errors/src/test_metric_errors.cpp
+++ b/negative_tests/tools/metric_errors/src/test_metric_errors.cpp
@@ -19,47 +19,48 @@ namespace lzt = level_zero_tests;
 
 namespace {
 
-TEST(MetricNegativeTests,
-     GivenInvalidMetricParametersThenGetParameterValidationErrorReturns) {
+// Temporarily disabling this test until stype and pNext validation in validation layer can be fixed.
+// TEST(MetricNegativeTests,
+//      GivenInvalidMetricParametersThenGetParameterValidationErrorReturns) {
 
-  auto driver = lzt::get_default_driver();
-  auto device = lzt::get_default_device(driver);
+//   auto driver = lzt::get_default_driver();
+//   auto device = lzt::get_default_device(driver);
 
-  zet_metric_group_handle_t test_handle =
-      reinterpret_cast<zet_metric_group_handle_t>(0xDEADBEEF);
-  zet_metric_streamer_handle_t streamer;
-  zet_metric_streamer_desc_t streamer_desc0 = {(zet_structure_type_t)0xaaaa,
-                                               nullptr, 1000, 40000};
-  zet_metric_streamer_desc_t streamer_desc1 = {
-      ZET_STRUCTURE_TYPE_METRIC_STREAMER_DESC, nullptr, 1000, 40000};
+//   zet_metric_group_handle_t test_handle =
+//       reinterpret_cast<zet_metric_group_handle_t>(0xDEADBEEF);
+//   zet_metric_streamer_handle_t streamer;
+//   zet_metric_streamer_desc_t streamer_desc0 = {(zet_structure_type_t)0xaaaa,
+//                                                nullptr, 1000, 40000};
+//   zet_metric_streamer_desc_t streamer_desc1 = {
+//       ZET_STRUCTURE_TYPE_METRIC_STREAMER_DESC, nullptr, 1000, 40000};
 
-  ASSERT_EQ(ZE_RESULT_ERROR_INVALID_NULL_HANDLE,
-            zetMetricStreamerOpen(nullptr, device, test_handle, &streamer_desc1,
-                                  nullptr, &streamer));
-  ASSERT_EQ(ZE_RESULT_ERROR_INVALID_NULL_HANDLE,
-            zetMetricStreamerOpen(lzt::get_default_context(), nullptr,
-                                  test_handle, &streamer_desc1, nullptr,
-                                  &streamer));
-  ASSERT_EQ(ZE_RESULT_ERROR_INVALID_NULL_HANDLE,
-            zetMetricStreamerOpen(lzt::get_default_context(), device, nullptr,
-                                  &streamer_desc1, nullptr, &streamer));
-  ASSERT_EQ(ZE_RESULT_ERROR_INVALID_NULL_POINTER,
-            zetMetricStreamerOpen(lzt::get_default_context(), device,
-                                  test_handle, nullptr, nullptr, &streamer));
-  ASSERT_EQ(ZE_RESULT_ERROR_INVALID_NULL_POINTER,
-            zetMetricStreamerOpen(lzt::get_default_context(), device,
-                                  test_handle, &streamer_desc1, nullptr,
-                                  nullptr));
-  ASSERT_EQ(ZE_RESULT_ERROR_INVALID_ARGUMENT,
-            zetMetricStreamerOpen(lzt::get_default_context(), device,
-                                  test_handle, &streamer_desc0, nullptr,
-                                  &streamer));
+//   ASSERT_EQ(ZE_RESULT_ERROR_INVALID_NULL_HANDLE,
+//             zetMetricStreamerOpen(nullptr, device, test_handle, &streamer_desc1,
+//                                   nullptr, &streamer));
+//   ASSERT_EQ(ZE_RESULT_ERROR_INVALID_NULL_HANDLE,
+//             zetMetricStreamerOpen(lzt::get_default_context(), nullptr,
+//                                   test_handle, &streamer_desc1, nullptr,
+//                                   &streamer));
+//   ASSERT_EQ(ZE_RESULT_ERROR_INVALID_NULL_HANDLE,
+//             zetMetricStreamerOpen(lzt::get_default_context(), device, nullptr,
+//                                   &streamer_desc1, nullptr, &streamer));
+//   ASSERT_EQ(ZE_RESULT_ERROR_INVALID_NULL_POINTER,
+//             zetMetricStreamerOpen(lzt::get_default_context(), device,
+//                                   test_handle, nullptr, nullptr, &streamer));
+//   ASSERT_EQ(ZE_RESULT_ERROR_INVALID_NULL_POINTER,
+//             zetMetricStreamerOpen(lzt::get_default_context(), device,
+//                                   test_handle, &streamer_desc1, nullptr,
+//                                   nullptr));
+//   ASSERT_EQ(ZE_RESULT_ERROR_INVALID_ARGUMENT,
+//             zetMetricStreamerOpen(lzt::get_default_context(), device,
+//                                   test_handle, &streamer_desc0, nullptr,
+//                                   &streamer));
 
-  streamer_desc1.pNext = &streamer_desc0;
-  ASSERT_EQ(ZE_RESULT_ERROR_INVALID_ARGUMENT,
-            zetMetricStreamerOpen(lzt::get_default_context(), device,
-                                  test_handle, &streamer_desc1, nullptr,
-                                  &streamer));
-}
+//   streamer_desc1.pNext = &streamer_desc0;
+//   ASSERT_EQ(ZE_RESULT_ERROR_INVALID_ARGUMENT,
+//             zetMetricStreamerOpen(lzt::get_default_context(), device,
+//                                   test_handle, &streamer_desc1, nullptr,
+//                                   &streamer));
+// }
 
 } // namespace


### PR DESCRIPTION
After removal of the stype/pnext check in the validation layer, remove these negative tests until the functionality can be reworked.