### PR TITLE
Fix dynamic tracing cts to reinit tracing

### DIFF
--- a/layer_tests/tracing/src/main.cpp
+++ b/layer_tests/tracing/src/main.cpp
@@ -25,14 +25,8 @@ int main(int argc, char **argv) {
     throw std::runtime_error("zeInit failed: " +
                              level_zero_tests::to_string(result));
   }
-#ifdef USE_RUNTIME_TRACING
-  zelEnableTracingLayer();
-#endif
   LOG_TRACE << "Driver initialized";
 
   auto ret = RUN_ALL_TESTS();
-#ifdef USE_RUNTIME_TRACING
-  zelDisableTracingLayer();
-#endif
   return ret;
 }

--- a/layer_tests/tracing/src/test_api_ltracing.cpp
+++ b/layer_tests/tracing/src/test_api_ltracing.cpp
@@ -17,6 +17,7 @@
 #include <boost/interprocess/shared_memory_object.hpp>
 #include <boost/interprocess/mapped_region.hpp>
 #include <boost/process.hpp>
+#include <level_zero/loader/ze_loader.h>
 
 namespace lzt = level_zero_tests;
 namespace bipc = boost::interprocess;
@@ -24,7 +25,12 @@ namespace bipc = boost::interprocess;
 namespace {
 
 #ifdef USE_RUNTIME_TRACING
-class LDynamicTracingCreateTests : public ::testing::Test {};
+class LDynamicTracingCreateTests : public ::testing::Test {
+protected:
+  void SetUp() override { zelEnableTracingLayer(); }
+
+  void TearDown() override { zelDisableTracingLayer(); }
+};
 #define LTRACING_CREATE_TEST_NAME LDynamicTracingCreateTests
 #else // USE Tracing ENV
 class LTracingCreateTests : public ::testing::Test {};
@@ -51,6 +57,10 @@ class LTracingCreateMultipleTests
 
 #ifdef USE_RUNTIME_TRACING
 class LDynamicTracingCreateMultipleTests : public LTracingCreateMultipleTests {
+protected:
+  void SetUp() override { zelEnableTracingLayer(); }
+
+  void TearDown() override { zelDisableTracingLayer(); }
 };
 #define LTRACING_CREATE_MULTIPLE_TEST_NAME LDynamicTracingCreateMultipleTests
 #else // USE Tracing ENV
@@ -85,7 +95,12 @@ INSTANTIATE_TEST_CASE_P(CreateMultipleTracerTest,
                         ::testing::Values(1, 10, 100, 1000));
 
 #ifdef USE_RUNTIME_TRACING
-class LDynamicTracingDestroyTests : public ::testing::Test {};
+class LDynamicTracingDestroyTests : public ::testing::Test {
+protected:
+  void SetUp() override { zelEnableTracingLayer(); }
+
+  void TearDown() override { zelDisableTracingLayer(); }
+};
 #define LTRACING_DESTROY_TEST_NAME LDynamicTracingDestroyTests
 #else // USE Tracing ENV
 class LTracingDestroyTests : public ::testing::Test {};
@@ -106,6 +121,9 @@ TEST(LTRACING_DESTROY_TEST_NAME,
 class LTracingPrologueEpilogueTests : public ::testing::Test {
 protected:
   void SetUp() override {
+#ifdef USE_RUNTIME_TRACING
+    zelEnableTracingLayer();
+#endif
     driver = lzt::get_default_driver();
     device = lzt::zeDevice::get_instance()->get_device();
     context = lzt::get_default_context();
@@ -281,6 +299,9 @@ protected:
       lzt::free_memory(memory);
     lzt::disable_ltracer(tracer_handle);
     lzt::destroy_ltracer_handle(tracer_handle);
+#ifdef USE_RUNTIME_TRACING
+    zelDisableTracingLayer();
+#endif
   }
 
   ze_context_handle_t context;

--- a/layer_tests/tracing/src/test_api_ltracing_compat.cpp
+++ b/layer_tests/tracing/src/test_api_ltracing_compat.cpp
@@ -20,6 +20,7 @@
 #include <boost/interprocess/shared_memory_object.hpp>
 #include <boost/interprocess/mapped_region.hpp>
 #include <boost/process.hpp>
+#include <level_zero/loader/ze_loader.h>
 
 namespace lzt = level_zero_tests;
 namespace bipc = boost::interprocess;
@@ -27,7 +28,12 @@ namespace bipc = boost::interprocess;
 namespace {
 
 #ifdef USE_RUNTIME_TRACING
-class LCDynamicTracingCreateTests : public ::testing::Test {};
+class LCDynamicTracingCreateTests : public ::testing::Test {
+protected:
+  void SetUp() override { zelEnableTracingLayer(); }
+
+  void TearDown() override { zelDisableTracingLayer(); }
+};
 #define LCTRACING_CREATE_TEST_NAME LCDynamicTracingCreateTests
 #else // USE Tracing ENV
 class LCTracingCreateTests : public ::testing::Test {};
@@ -54,7 +60,12 @@ class LCTracingCreateMultipleTests
 
 #ifdef USE_RUNTIME_TRACING
 class LCDynamicTracingCreateMultipleTests
-    : public LCTracingCreateMultipleTests {};
+    : public LCTracingCreateMultipleTests {
+protected:
+  void SetUp() override { zelEnableTracingLayer(); }
+
+  void TearDown() override { zelDisableTracingLayer(); }
+};
 #define LCTRACING_CREATE_MULTIPLE_TEST_NAME LCDynamicTracingCreateMultipleTests
 #else // USE Tracing ENV
 #define LCTRACING_CREATE_MULTIPLE_TEST_NAME LCTracingCreateMultipleTests
@@ -88,7 +99,12 @@ INSTANTIATE_TEST_CASE_P(LCCreateMultipleTracerTest,
                         ::testing::Values(1, 10, 100, 1000));
 
 #ifdef USE_RUNTIME_TRACING
-class LCDynamicTracingDestroyTests : public ::testing::Test {};
+class LCDynamicTracingDestroyTests : public ::testing::Test {
+protected:
+  void SetUp() override { zelEnableTracingLayer(); }
+
+  void TearDown() override { zelDisableTracingLayer(); }
+};
 #define LCTRACING_DESTROY_TEST_NAME LCDynamicTracingDestroyTests
 #else // USE Tracing ENV
 class LCTracingDestroyTests : public ::testing::Test {};
@@ -109,6 +125,9 @@ TEST(LCTRACING_DESTROY_TEST_NAME,
 class LCTracingPrologueEpilogueTests : public ::testing::Test {
 protected:
   void SetUp() override {
+#ifdef USE_RUNTIME_TRACING
+    zelEnableTracingLayer();
+#endif
     driver = lzt::get_default_driver();
     device = lzt::zeDevice::get_instance()->get_device();
     context = lzt::get_default_context();
@@ -288,6 +307,9 @@ protected:
       lzt::free_memory(memory);
     lzt::disable_ltracer(tracer_handle);
     lzt::destroy_ltracer_handle(tracer_handle);
+#ifdef USE_RUNTIME_TRACING
+    zelDisableTracingLayer();
+#endif
   }
 
   ze_context_handle_t context;

--- a/layer_tests/tracing/src/test_api_ltracing_threading.cpp
+++ b/layer_tests/tracing/src/test_api_ltracing_threading.cpp
@@ -15,6 +15,7 @@
 #include "test_harness/test_harness.hpp"
 #include <level_zero/ze_api.h>
 #include <level_zero/zet_api.h>
+#include <level_zero/loader/ze_loader.h>
 
 namespace lzt = level_zero_tests;
 
@@ -57,6 +58,9 @@ void allocate_then_deallocate_device_memory() {
 class LTracingThreadTests : public ::testing::Test {
 protected:
   void SetUp() override {
+#ifdef USE_RUNTIME_TRACING
+    zelEnableTracingLayer();
+#endif
     callback_exit_invocations = 0;
     callback_enter_invocations = 0;
     ready = false;
@@ -80,6 +84,9 @@ protected:
   void TearDown() {
     lzt::disable_ltracer(tracer);
     lzt::destroy_ltracer_handle(tracer);
+#ifdef USE_RUNTIME_TRACING
+    zelDisableTracingLayer();
+#endif
   }
 
   zel_tracer_handle_t tracer;
@@ -175,7 +182,11 @@ TEST_F(
 
 class LTracingThreadTestsDisabling : public LTracingThreadTests {
 protected:
-  void TearDown() override {}
+  void TearDown() override {
+#ifdef USE_RUNTIME_TRACING
+    zelDisableTracingLayer();
+#endif
+  }
 };
 
 #ifdef USE_RUNTIME_TRACING


### PR DESCRIPTION
-Addresses the issue with dynamic tracing tests running without a gtest filter, this properly resets the tracing for each test run.