### PR TITLE
Fix: fixes the seg fault in the below frequency sysman test

### DIFF
--- a/conformance_tests/sysman/test_sysman_frequency/CMakeLists.txt
+++ b/conformance_tests/sysman/test_sysman_frequency/CMakeLists.txt
@@ -26,3 +26,5 @@ add_lzt_test(
     sysman_matrix_multiplication
   DEFINES USE_ZESINIT  
 )
+
+add_definitions(-DMATRIX_MUL_SPV_PATH="${CMAKE_SOURCE_DIR}/conformance_tests/sysman/test_sysman_frequency/kernels/sysman_matrix_multiplication.spv")

--- a/conformance_tests/sysman/test_sysman_frequency/src/test_sysman_frequency.cpp
+++ b/conformance_tests/sysman/test_sysman_frequency/src/test_sysman_frequency.cpp
@@ -493,9 +493,9 @@ void load_for_gpu(ze_device_handle_t target_device) {
   void *a_buffer = lzt::allocate_host_memory(m * k * sizeof(float));
   void *b_buffer = lzt::allocate_host_memory(k * n * sizeof(float));
   void *c_buffer = lzt::allocate_host_memory(m * n * sizeof(float));
-  ze_module_handle_t module =
-      lzt::create_module(device, "sysman_matrix_multiplication.spv",
-                         ZE_MODULE_FORMAT_IL_SPIRV, nullptr, nullptr);
+  std::string spv_path = std::string(MATRIX_MUL_SPV_PATH);
+  ze_module_handle_t module = lzt::create_module(
+      device, spv_path.c_str(), ZE_MODULE_FORMAT_IL_SPIRV, nullptr, nullptr);
   ze_kernel_handle_t function =
       lzt::create_function(module, "sysman_matrix_multiplication");
   lzt::set_group_size(function, 16, 16, 1);
@@ -649,9 +649,9 @@ void loadForGpuMaxFreqTest(ze_device_handle_t target_device) {
   void *a_buffer = lzt::allocate_host_memory(m * k * sizeof(float));
   void *b_buffer = lzt::allocate_host_memory(k * n * sizeof(float));
   void *c_buffer = lzt::allocate_host_memory(m * n * sizeof(float));
-  ze_module_handle_t module =
-      lzt::create_module(device, "sysman_matrix_multiplication.spv",
-                         ZE_MODULE_FORMAT_IL_SPIRV, nullptr, nullptr);
+  std::string spv_path = std::string(MATRIX_MUL_SPV_PATH);
+  ze_module_handle_t module = lzt::create_module(
+      device, spv_path.c_str(), ZE_MODULE_FORMAT_IL_SPIRV, nullptr, nullptr);
   ze_kernel_handle_t function =
       lzt::create_function(module, "sysman_matrix_multiplication");
   lzt::set_group_size(function, 16, 16, 1);


### PR DESCRIPTION
GivenValidFrequencyRangeWhenRequestingSetFrequencyThenExpectRequestFrequencyStaysInRangeDuringGpuLoad

Related-To: VLCLJ-2461