### PR TITLE
fix: git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 # Editor temporary files
 *~
 .*.sw?
+/.vscode

--- a/conformance_tests/core/test_cmdlist/src/test_cmdlist.cpp
+++ b/conformance_tests/core/test_cmdlist/src/test_cmdlist.cpp
@@ -985,9 +985,10 @@ TEST_F(
   for (int i = 1; i <= cmdlist.size(); i++) {
     LOG_INFO << "Testing " << i << " command list(s)";
     const size_t size = 16;
-    void *buffer = reinterpret_cast<void *>(new int[i * size]);
+    int *buffer = new int[i * size];
     ASSERT_NE(nullptr, buffer);
-    RunAppendLaunchKernelEvent(cmdlist, cmdqueue, event0, i, buffer, size);
+    RunAppendLaunchKernelEvent(cmdlist, cmdqueue, event0, i,
+                               reinterpret_cast<void *>(buffer), size);
     delete[] buffer;
   }
 }
@@ -1009,7 +1010,6 @@ TEST_F(
     ASSERT_NE(nullptr, buffer);
     RunAppendLaunchKernelEvent(cmdlist, cmdqueue, event0, i,
                                reinterpret_cast<void *>(buffer.get()), size);
-    delete[] buffer;
   }
 }
 

--- a/conformance_tests/core/test_cmdlist/src/test_cmdlist.cpp
+++ b/conformance_tests/core/test_cmdlist/src/test_cmdlist.cpp
@@ -973,8 +973,8 @@ TEST_F(
 }
 
 TEST_F(
-  zeCommandListEventCounterTests,
-  GivenInOrderCommandListWhenAppendLaunchKernelInstructionCounterEventThenVerifyImmediateExecutionWithSharedSystemAllocatorNew) {
+    zeCommandListEventCounterTests,
+    GivenInOrderCommandListWhenAppendLaunchKernelInstructionCounterEventThenVerifyImmediateExecutionWithSharedSystemAllocatorNew) {
 
   bool event_pool_ext_found = lzt::check_if_extension_supported(
       lzt::get_default_driver(), "ZE_experimental_event_pool_counter_based");

--- a/conformance_tests/core/test_cmdlist/src/test_cmdlist.cpp
+++ b/conformance_tests/core/test_cmdlist/src/test_cmdlist.cpp
@@ -1007,7 +1007,8 @@ TEST_F(
     const size_t size = 16;
     std::unique_ptr<int[]> buffer(new int[i * size]);
     ASSERT_NE(nullptr, buffer);
-    RunAppendLaunchKernelEvent(cmdlist, cmdqueue, event0, i, buffer, size);
+    RunAppendLaunchKernelEvent(cmdlist, cmdqueue, event0, i,
+                               reinterpret_cast<void *>(buffer.get()), size);
     delete[] buffer;
   }
 }
@@ -1027,7 +1028,8 @@ TEST_F(
     const size_t size = 16;
     std::shared_ptr<int[]> buffer(new int[i * size]);
     ASSERT_NE(nullptr, buffer);
-    RunAppendLaunchKernelEvent(cmdlist, cmdqueue, event0, i, reinterpret_cast<void *>(buffer.get()), size);
+    RunAppendLaunchKernelEvent(cmdlist, cmdqueue, event0, i,
+                               reinterpret_cast<void *>(buffer.get()), size);
   }
 }
 

--- a/conformance_tests/core/test_cmdlist/src/test_cmdlist.cpp
+++ b/conformance_tests/core/test_cmdlist/src/test_cmdlist.cpp
@@ -976,20 +976,20 @@ TEST_F(
   zeCommandListEventCounterTests,
   GivenInOrderCommandListWhenAppendLaunchKernelInstructionCounterEventThenVerifyImmediateExecutionWithSharedSystemAllocatorNew) {
 
-bool event_pool_ext_found = lzt::check_if_extension_supported(
-    lzt::get_default_driver(), "ZE_experimental_event_pool_counter_based");
-EXPECT_TRUE(event_pool_ext_found);
+  bool event_pool_ext_found = lzt::check_if_extension_supported(
+      lzt::get_default_driver(), "ZE_experimental_event_pool_counter_based");
+  EXPECT_TRUE(event_pool_ext_found);
 
-lzt::gtest_skip_if_shared_system_alloc_unsupported(true);
+  lzt::gtest_skip_if_shared_system_alloc_unsupported(true);
 
-for (int i = 1; i <= cmdlist.size(); i++) {
-  LOG_INFO << "Testing " << i << " command list(s)";
-  const size_t size = 16;
-  void *buffer = reinterpret_cast<void *>(new int[i * size]);
-  ASSERT_NE(nullptr, buffer);
-  RunAppendLaunchKernelEvent(cmdlist, cmdqueue, event0, i, buffer, size);
-  delete [] buffer;
-}
+  for (int i = 1; i <= cmdlist.size(); i++) {
+    LOG_INFO << "Testing " << i << " command list(s)";
+    const size_t size = 16;
+    void *buffer = reinterpret_cast<void *>(new int[i * size]);
+    ASSERT_NE(nullptr, buffer);
+    RunAppendLaunchKernelEvent(cmdlist, cmdqueue, event0, i, buffer, size);
+    delete [] buffer;
+  }
 }
 
 } // namespace

--- a/conformance_tests/core/test_cmdlist/src/test_cmdlist.cpp
+++ b/conformance_tests/core/test_cmdlist/src/test_cmdlist.cpp
@@ -972,4 +972,24 @@ TEST_F(
   }
 }
 
+TEST_F(
+  zeCommandListEventCounterTests,
+  GivenInOrderCommandListWhenAppendLaunchKernelInstructionCounterEventThenVerifyImmediateExecutionWithSharedSystemAllocatorNew) {
+
+bool event_pool_ext_found = lzt::check_if_extension_supported(
+    lzt::get_default_driver(), "ZE_experimental_event_pool_counter_based");
+EXPECT_TRUE(event_pool_ext_found);
+
+lzt::gtest_skip_if_shared_system_alloc_unsupported(true);
+
+for (int i = 1; i <= cmdlist.size(); i++) {
+  LOG_INFO << "Testing " << i << " command list(s)";
+  const size_t size = 16;
+  void *buffer = reinterpret_cast<void *>(new int[i * size]);
+  ASSERT_NE(nullptr, buffer);
+  RunAppendLaunchKernelEvent(cmdlist, cmdqueue, event0, i, buffer, size);
+  delete [] buffer;
+}
+}
+
 } // namespace

--- a/conformance_tests/core/test_cmdlist/src/test_cmdlist.cpp
+++ b/conformance_tests/core/test_cmdlist/src/test_cmdlist.cpp
@@ -954,7 +954,7 @@ TEST_F(
 
 TEST_F(
     zeCommandListEventCounterTests,
-    GivenInOrderCommandListWhenAppendLaunchKernelInstructionCounterEventThenVerifyImmediateExecutionWithSharedSystemAllocator) {
+    GivenInOrderCommandListWhenAppendLaunchKernelInstructionCounterEventThenVerifyImmediateExecutionWithSharedSystemAllocatorMalloc) {
 
   bool event_pool_ext_found = lzt::check_if_extension_supported(
       lzt::get_default_driver(), "ZE_experimental_event_pool_counter_based");
@@ -989,6 +989,45 @@ TEST_F(
     ASSERT_NE(nullptr, buffer);
     RunAppendLaunchKernelEvent(cmdlist, cmdqueue, event0, i, buffer, size);
     delete[] buffer;
+  }
+}
+
+TEST_F(
+    zeCommandListEventCounterTests,
+    GivenInOrderCommandListWhenAppendLaunchKernelInstructionCounterEventThenVerifyImmediateExecutionWithSharedSystemAllocatorUniquePtr) {
+
+  bool event_pool_ext_found = lzt::check_if_extension_supported(
+      lzt::get_default_driver(), "ZE_experimental_event_pool_counter_based");
+  EXPECT_TRUE(event_pool_ext_found);
+
+  lzt::gtest_skip_if_shared_system_alloc_unsupported(true);
+
+  for (int i = 1; i <= cmdlist.size(); i++) {
+    LOG_INFO << "Testing " << i << " command list(s)";
+    const size_t size = 16;
+    std::unique_ptr<int[]> buffer(new int[i * size]);
+    ASSERT_NE(nullptr, buffer);
+    RunAppendLaunchKernelEvent(cmdlist, cmdqueue, event0, i, buffer, size);
+    delete[] buffer;
+  }
+}
+
+TEST_F(
+    zeCommandListEventCounterTests,
+    GivenInOrderCommandListWhenAppendLaunchKernelInstructionCounterEventThenVerifyImmediateExecutionWithSharedSystemAllocatorSharedPtr) {
+
+  bool event_pool_ext_found = lzt::check_if_extension_supported(
+      lzt::get_default_driver(), "ZE_experimental_event_pool_counter_based");
+  EXPECT_TRUE(event_pool_ext_found);
+
+  lzt::gtest_skip_if_shared_system_alloc_unsupported(true);
+
+  for (int i = 1; i <= cmdlist.size(); i++) {
+    LOG_INFO << "Testing " << i << " command list(s)";
+    const size_t size = 16;
+    std::shared_ptr<int[]> buffer(new int[i * size]);
+    ASSERT_NE(nullptr, buffer);
+    RunAppendLaunchKernelEvent(cmdlist, cmdqueue, event0, i, reinterpret_cast<void *>(buffer.get()), size);
   }
 }
 

--- a/conformance_tests/core/test_cmdlist/src/test_cmdlist.cpp
+++ b/conformance_tests/core/test_cmdlist/src/test_cmdlist.cpp
@@ -988,7 +988,7 @@ TEST_F(
     void *buffer = reinterpret_cast<void *>(new int[i * size]);
     ASSERT_NE(nullptr, buffer);
     RunAppendLaunchKernelEvent(cmdlist, cmdqueue, event0, i, buffer, size);
-    delete [] buffer;
+    delete[] buffer;
   }
 }
 


### PR DESCRIPTION
Using VS Code creates editor config files that don't need to be included in the CTS repository. This updates `.gitignore` to filter out the `.vscode` folder.