### PR TITLE
Fix: replace gtest_skip_if_shared_system_alloc_unsupported to stop shared system allocation tests

### DIFF
--- a/conformance_tests/core/test_cmdlist/src/test_cmdlist.cpp
+++ b/conformance_tests/core/test_cmdlist/src/test_cmdlist.cpp
@@ -1022,7 +1022,7 @@ TEST_F(
 TEST_F(
     zeCommandListEventCounterTests,
     GivenInOrderCommandListWhenAppendLaunchKernelInstructionCounterEventThenVerifyImmediateExecutionUsingMallocWithSharedSystemAllocator) {
-  lzt::gtest_skip_if_shared_system_alloc_unsupported(true);
+  SKIP_IF_SHARED_SYSTEM_ALLOC_UNSUPPORTED(true);
   RunAppendLaunchKernelEventLoop(cmdlist, cmdqueue, event0,
                                  RunAppendLaunchKernelEventHostMalloc);
 }
@@ -1030,7 +1030,7 @@ TEST_F(
 TEST_F(
     zeCommandListEventCounterTests,
     GivenInOrderCommandListWhenAppendLaunchKernelInstructionCounterEventThenVerifyImmediateExecutionUsingNewWithSharedSystemAllocator) {
-  lzt::gtest_skip_if_shared_system_alloc_unsupported(true);
+  SKIP_IF_SHARED_SYSTEM_ALLOC_UNSUPPORTED(true);
   RunAppendLaunchKernelEventLoop(cmdlist, cmdqueue, event0,
                                  RunAppendLaunchKernelEventHostNew);
 }
@@ -1038,7 +1038,7 @@ TEST_F(
 TEST_F(
     zeCommandListEventCounterTests,
     GivenInOrderCommandListWhenAppendLaunchKernelInstructionCounterEventThenVerifyImmediateExecutionUsingUniquePtrWithSharedSystemAllocator) {
-  lzt::gtest_skip_if_shared_system_alloc_unsupported(true);
+  SKIP_IF_SHARED_SYSTEM_ALLOC_UNSUPPORTED(true);
   RunAppendLaunchKernelEventLoop(cmdlist, cmdqueue, event0,
                                  RunAppendLaunchKernelEventHostUniquePtr);
 }
@@ -1046,7 +1046,7 @@ TEST_F(
 TEST_F(
     zeCommandListEventCounterTests,
     GivenInOrderCommandListWhenAppendLaunchKernelInstructionCounterEventThenVerifyImmediateExecutionUsingSharedPtrWithSharedSystemAllocator) {
-  lzt::gtest_skip_if_shared_system_alloc_unsupported(true);
+  SKIP_IF_SHARED_SYSTEM_ALLOC_UNSUPPORTED(true);
   RunAppendLaunchKernelEventLoop(cmdlist, cmdqueue, event0,
                                  RunAppendLaunchKernelEventHostSharedPtr);
 }

--- a/conformance_tests/core/test_cmdlist/src/test_cmdlist.cpp
+++ b/conformance_tests/core/test_cmdlist/src/test_cmdlist.cpp
@@ -1022,7 +1022,7 @@ TEST_F(
 TEST_F(
     zeCommandListEventCounterTests,
     GivenInOrderCommandListWhenAppendLaunchKernelInstructionCounterEventThenVerifyImmediateExecutionUsingMallocWithSharedSystemAllocator) {
-  SKIP_IF_SHARED_SYSTEM_ALLOC_UNSUPPORTED(true);
+  SKIP_IF_SHARED_SYSTEM_ALLOC_UNSUPPORTED();
   RunAppendLaunchKernelEventLoop(cmdlist, cmdqueue, event0,
                                  RunAppendLaunchKernelEventHostMalloc);
 }
@@ -1030,7 +1030,7 @@ TEST_F(
 TEST_F(
     zeCommandListEventCounterTests,
     GivenInOrderCommandListWhenAppendLaunchKernelInstructionCounterEventThenVerifyImmediateExecutionUsingNewWithSharedSystemAllocator) {
-  SKIP_IF_SHARED_SYSTEM_ALLOC_UNSUPPORTED(true);
+  SKIP_IF_SHARED_SYSTEM_ALLOC_UNSUPPORTED();
   RunAppendLaunchKernelEventLoop(cmdlist, cmdqueue, event0,
                                  RunAppendLaunchKernelEventHostNew);
 }
@@ -1038,7 +1038,7 @@ TEST_F(
 TEST_F(
     zeCommandListEventCounterTests,
     GivenInOrderCommandListWhenAppendLaunchKernelInstructionCounterEventThenVerifyImmediateExecutionUsingUniquePtrWithSharedSystemAllocator) {
-  SKIP_IF_SHARED_SYSTEM_ALLOC_UNSUPPORTED(true);
+  SKIP_IF_SHARED_SYSTEM_ALLOC_UNSUPPORTED();
   RunAppendLaunchKernelEventLoop(cmdlist, cmdqueue, event0,
                                  RunAppendLaunchKernelEventHostUniquePtr);
 }
@@ -1046,7 +1046,7 @@ TEST_F(
 TEST_F(
     zeCommandListEventCounterTests,
     GivenInOrderCommandListWhenAppendLaunchKernelInstructionCounterEventThenVerifyImmediateExecutionUsingSharedPtrWithSharedSystemAllocator) {
-  SKIP_IF_SHARED_SYSTEM_ALLOC_UNSUPPORTED(true);
+  SKIP_IF_SHARED_SYSTEM_ALLOC_UNSUPPORTED();
   RunAppendLaunchKernelEventLoop(cmdlist, cmdqueue, event0,
                                  RunAppendLaunchKernelEventHostSharedPtr);
 }

--- a/conformance_tests/core/test_cmdlist/src/test_cmdlist_immediate.cpp
+++ b/conformance_tests/core/test_cmdlist/src/test_cmdlist_immediate.cpp
@@ -200,8 +200,6 @@ TEST_F(
 void zeImmediateCommandListExecutionTests::
     RunGivenImmediateCommandListWhenAppendLaunchKernelInstructionTest(
         bool is_shared_system) {
-  SKIP_IF_SHARED_SYSTEM_ALLOC_UNSUPPORTED(is_shared_system);
-
   const size_t size = 16;
   const int addval = 10;
   const int addval2 = 15;
@@ -265,14 +263,13 @@ TEST_P(
 TEST_P(
     zeImmediateCommandListExecutionTests,
     GivenImmediateCommandListWhenAppendLaunchKernelInstructionThenVerifyImmediateExecutionWithSharedSystemAllocator) {
+  SKIP_IF_SHARED_SYSTEM_ALLOC_UNSUPPORTED();
   RunGivenImmediateCommandListWhenAppendLaunchKernelInstructionTest(true);
 }
 
 static void RunAppendLaunchKernel(ze_command_list_handle_t cmdlist_immediate,
                                   ze_command_queue_mode_t mode,
                                   bool is_shared_system) {
-  SKIP_IF_SHARED_SYSTEM_ALLOC_UNSUPPORTED(is_shared_system);
-
   const size_t size = 16;
   const int addval = 10;
   int addval2 = 15;
@@ -338,6 +335,7 @@ TEST_F(
 TEST_F(
     zeImmediateCommandListInOrderExecutionTests,
     GivenInOrderImmediateCommandListWhenAppendLaunchKernelInstructionThenVerifyImmediateExecutionWithSharedSystemAllocator) {
+  SKIP_IF_SHARED_SYSTEM_ALLOC_UNSUPPORTED();
   RunAppendLaunchKernel(cmdlist_immediate_default_mode,
                         ZE_COMMAND_QUEUE_MODE_DEFAULT, true);
   RunAppendLaunchKernel(cmdlist_immediate_sync_mode,
@@ -350,8 +348,6 @@ static void
 RunAppendLaunchKernelEvent(std::vector<ze_command_list_handle_t> cmdlist,
                            ze_event_handle_t event, int num_cmdlist,
                            bool is_shared_system) {
-  SKIP_IF_SHARED_SYSTEM_ALLOC_UNSUPPORTED(is_shared_system);
-
   const size_t size = 16;
   const int addval = 10;
   const int num_iterations = 100;
@@ -433,6 +429,7 @@ TEST_F(
 TEST_F(
     zeImmediateCommandListEventCounterTests,
     GivenInOrderImmediateCommandListWhenAppendLaunchKernelInstructionCounterEventThenVerifyImmediateExecutionWithSharedSystemAllocator) {
+  SKIP_IF_SHARED_SYSTEM_ALLOC_UNSUPPORTED();
 
   bool event_pool_ext_found = lzt::check_if_extension_supported(
       lzt::get_default_driver(), "ZE_experimental_event_pool_counter_based");

--- a/conformance_tests/core/test_cmdlist/src/test_cmdlist_immediate.cpp
+++ b/conformance_tests/core/test_cmdlist/src/test_cmdlist_immediate.cpp
@@ -200,7 +200,7 @@ TEST_F(
 void zeImmediateCommandListExecutionTests::
     RunGivenImmediateCommandListWhenAppendLaunchKernelInstructionTest(
         bool is_shared_system) {
-  lzt::gtest_skip_if_shared_system_alloc_unsupported(is_shared_system);
+  SKIP_IF_SHARED_SYSTEM_ALLOC_UNSUPPORTED(is_shared_system);
 
   const size_t size = 16;
   const int addval = 10;
@@ -271,7 +271,7 @@ TEST_P(
 static void RunAppendLaunchKernel(ze_command_list_handle_t cmdlist_immediate,
                                   ze_command_queue_mode_t mode,
                                   bool is_shared_system) {
-  lzt::gtest_skip_if_shared_system_alloc_unsupported(is_shared_system);
+  SKIP_IF_SHARED_SYSTEM_ALLOC_UNSUPPORTED(is_shared_system);
 
   const size_t size = 16;
   const int addval = 10;
@@ -350,7 +350,7 @@ static void
 RunAppendLaunchKernelEvent(std::vector<ze_command_list_handle_t> cmdlist,
                            ze_event_handle_t event, int num_cmdlist,
                            bool is_shared_system) {
-  lzt::gtest_skip_if_shared_system_alloc_unsupported(is_shared_system);
+  SKIP_IF_SHARED_SYSTEM_ALLOC_UNSUPPORTED(is_shared_system);
 
   const size_t size = 16;
   const int addval = 10;

--- a/conformance_tests/core/test_cmdlist/src/test_cmdlist_mixed.cpp
+++ b/conformance_tests/core/test_cmdlist/src/test_cmdlist_mixed.cpp
@@ -1608,7 +1608,7 @@ RunAppendLaunchKernelEvent(std::vector<ze_command_list_handle_t> cmdlist,
                            std::vector<ze_command_queue_handle_t> cmdqueue,
                            ze_event_handle_t event, int num_cmdlist,
                            bool is_shared_system) {
-  lzt::gtest_skip_if_shared_system_alloc_unsupported(is_shared_system);
+  SKIP_IF_SHARED_SYSTEM_ALLOC_UNSUPPORTED(is_shared_system);
 
   const size_t size = 16;
   const int addval = 10;
@@ -1789,7 +1789,7 @@ static void RunOutOfOrderAppendLaunchKernelEvent(
     std::vector<ze_command_queue_handle_t> cmdqueue,
     ze_event_handle_t counter_event, ze_event_handle_t event, bool is_immediate,
     bool is_shared_system) {
-  lzt::gtest_skip_if_shared_system_alloc_unsupported(is_shared_system);
+  SKIP_IF_SHARED_SYSTEM_ALLOC_UNSUPPORTED(is_shared_system);
 
   int num_cmdlist = 2;
   const size_t size = 16;

--- a/conformance_tests/core/test_cmdlist/src/test_cmdlist_mixed.cpp
+++ b/conformance_tests/core/test_cmdlist/src/test_cmdlist_mixed.cpp
@@ -1608,8 +1608,6 @@ RunAppendLaunchKernelEvent(std::vector<ze_command_list_handle_t> cmdlist,
                            std::vector<ze_command_queue_handle_t> cmdqueue,
                            ze_event_handle_t event, int num_cmdlist,
                            bool is_shared_system) {
-  SKIP_IF_SHARED_SYSTEM_ALLOC_UNSUPPORTED(is_shared_system);
-
   const size_t size = 16;
   const int addval = 10;
   const int num_iterations = 100;
@@ -1703,6 +1701,7 @@ TEST_F(
 TEST_F(
     zeMixedCommandListEventCounterTests,
     GivenInOrderMixedCommandListWhenAppendLaunchKernelInstructionCounterEventThenVerifyImmediateExecutionWithSharedSystemAllocator) {
+  SKIP_IF_SHARED_SYSTEM_ALLOC_UNSUPPORTED();
 
   bool event_pool_ext_found = lzt::check_if_extension_supported(
       lzt::get_default_driver(), "ZE_experimental_event_pool_counter_based");
@@ -1789,8 +1788,6 @@ static void RunOutOfOrderAppendLaunchKernelEvent(
     std::vector<ze_command_queue_handle_t> cmdqueue,
     ze_event_handle_t counter_event, ze_event_handle_t event, bool is_immediate,
     bool is_shared_system) {
-  SKIP_IF_SHARED_SYSTEM_ALLOC_UNSUPPORTED(is_shared_system);
-
   int num_cmdlist = 2;
   const size_t size = 16;
   const int addval = 10;
@@ -1906,6 +1903,7 @@ TEST_F(
 TEST_F(
     zeOutOfOrderCommandListEventCounterTests,
     GivenOutOfOrderRegularCommandListWhenAppendLaunchKernelInstructionCounterEventThenVerifyWaitForEventWithSharedSystemAllocator) {
+  SKIP_IF_SHARED_SYSTEM_ALLOC_UNSUPPORTED();
 
   bool event_pool_ext_found = lzt::check_if_extension_supported(
       lzt::get_default_driver(), "ZE_experimental_event_pool_counter_based");
@@ -1930,6 +1928,7 @@ TEST_F(
 TEST_F(
     zeOutOfOrderCommandListEventCounterTests,
     GivenOutOfOrderImmediateCommandListWhenAppendLaunchKernelInstructionCounterEventThenVerifyWaitForEventWithSharedSystemAllocator) {
+  SKIP_IF_SHARED_SYSTEM_ALLOC_UNSUPPORTED();
 
   bool event_pool_ext_found = lzt::check_if_extension_supported(
       lzt::get_default_driver(), "ZE_experimental_event_pool_counter_based");

--- a/conformance_tests/core/test_copy/src/test_copy.cpp
+++ b/conformance_tests/core/test_copy/src/test_copy.cpp
@@ -1193,10 +1193,7 @@ class zeSharedSystemMemoryCopyTests
           std::tuple<ze_memory_type_t, size_t, size_t>> {
 protected:
   void SetUp() override {
-    const auto memory_access_properties = lzt::get_memory_access_properties(
-        lzt::get_default_device(lzt::get_default_driver()));
-    if ((memory_access_properties.sharedSystemAllocCapabilities &
-         ZE_MEMORY_ACCESS_CAP_FLAG_RW) == 0) {
+    if (!lzt::supports_shared_system_alloc()) {
       GTEST_SKIP() << "Device does not support accessing shared system memory";
     }
   }

--- a/conformance_tests/core/test_copy/src/test_kernel_copy.cpp
+++ b/conformance_tests/core/test_copy/src/test_kernel_copy.cpp
@@ -277,9 +277,7 @@ protected:
                                                   device, context, &result);
     } else { // shared
       if (shr_type == SHARED_SYSTEM) {
-        auto memory_access_cap =
-            mem_access_properties.sharedSystemAllocCapabilities;
-        if ((memory_access_cap & ZE_MEMORY_ACCESS_CAP_FLAG_RW) == 0) {
+        if (!lzt::supports_shared_system_alloc(mem_access_properties)) {
           LOG_INFO
               << "WARNING: Unable to allocate shared system memory, skipping";
           return nullptr;

--- a/conformance_tests/core/test_memory/src/test_memory.cpp
+++ b/conformance_tests/core/test_memory/src/test_memory.cpp
@@ -895,10 +895,7 @@ TEST_F(
 class zeHostSystemMemoryDeviceTests : public ::testing::Test {
 protected:
   void SetUp() override {
-    auto mem_access_props = lzt::get_memory_access_properties(
-        lzt::get_default_device(lzt::get_default_driver()));
-    systemMemSupported = mem_access_props.sharedSystemAllocCapabilities &
-                         ZE_MEMORY_ACCESS_CAP_FLAG_RW;
+    systemMemSupported = lzt::supports_shared_system_alloc();
     memory_ = new uint8_t[size_];
   }
   void TearDown() override { delete[] memory_; }

--- a/conformance_tests/core/test_memory_overcommit/src/test_memory_overcommit.cpp
+++ b/conformance_tests/core/test_memory_overcommit/src/test_memory_overcommit.cpp
@@ -375,9 +375,7 @@ protected:
             (uint64_t *)level_zero_tests::allocate_shared_memory(
                 output_size_, 8, 0u, 0u, device_handle, context);
       } else if (shr_mem_type == SHARED_SYSTEM) { // system allocation
-        auto memory_access_cap =
-            device_properties.sharedSystemAllocCapabilities;
-        if ((memory_access_cap & ZE_MEMORY_ACCESS_CAP_FLAG_RW) == 0) {
+        if (!lzt::supports_shared_system_alloc(device_properties)) {
           LOG_INFO
               << "WARNING: Unable to allocate shared system memory, skipping";
           free_drivers_info();

--- a/conformance_tests/core/test_module/src/test_cooperative_kernel.cpp
+++ b/conformance_tests/core/test_module/src/test_cooperative_kernel.cpp
@@ -29,8 +29,6 @@ protected:
 void CooperativeKernelTests::
     RunGivenCooperativeKernelWhenAppendingLaunchCooperativeKernelTest(
         bool is_shared_system) {
-  SKIP_IF_SHARED_SYSTEM_ALLOC_UNSUPPORTED(is_shared_system);
-
   uint32_t max_group_count = 0;
   ze_module_handle_t module = nullptr;
   ze_kernel_handle_t kernel = nullptr;
@@ -123,6 +121,7 @@ TEST_P(
 TEST_P(
     CooperativeKernelTests,
     GivenCooperativeKernelWhenAppendingLaunchCooperativeKernelThenSuccessIsReturnedAndOutputIsCorrectWithSharedSystemAllocator) {
+  SKIP_IF_SHARED_SYSTEM_ALLOC_UNSUPPORTED();
   RunGivenCooperativeKernelWhenAppendingLaunchCooperativeKernelTest(true);
 }
 

--- a/conformance_tests/core/test_module/src/test_cooperative_kernel.cpp
+++ b/conformance_tests/core/test_module/src/test_cooperative_kernel.cpp
@@ -29,7 +29,7 @@ protected:
 void CooperativeKernelTests::
     RunGivenCooperativeKernelWhenAppendingLaunchCooperativeKernelTest(
         bool is_shared_system) {
-  lzt::gtest_skip_if_shared_system_alloc_unsupported(is_shared_system);
+  SKIP_IF_SHARED_SYSTEM_ALLOC_UNSUPPORTED(is_shared_system);
 
   uint32_t max_group_count = 0;
   ze_module_handle_t module = nullptr;

--- a/conformance_tests/core/test_module/src/test_module.cpp
+++ b/conformance_tests/core/test_module/src/test_module.cpp
@@ -1215,8 +1215,6 @@ protected:
 void zeKernelLaunchTests::test_kernel_execution(enum TestType test_type,
                                                 const bool is_immediate,
                                                 bool is_shared_system) {
-  SKIP_IF_SHARED_SYSTEM_ALLOC_UNSUPPORTED(is_shared_system);
-
   ze_device_compute_properties_t dev_compute_properties = {};
   dev_compute_properties.stype = ZE_STRUCTURE_TYPE_DEVICE_COMPUTE_PROPERTIES;
   dev_compute_properties.pNext = nullptr;
@@ -1284,12 +1282,14 @@ TEST_P(
 TEST_F(
     zeKernelLaunchTests,
     GivenValidFunctionWhenAppendLaunchKernelThenReturnSuccessfulAndVerifyExecutionWithSharedSystemAllocator) {
+  SKIP_IF_SHARED_SYSTEM_ALLOC_UNSUPPORTED();
   test_kernel_execution(FUNCTION, false, true);
 }
 
 TEST_F(
     zeKernelLaunchTests,
     GivenValidFunctionWhenAppendLaunchKernelOnImmediateCmdListThenReturnSuccessfulAndVerifyExecutionWithSharedSystemAllocator) {
+  SKIP_IF_SHARED_SYSTEM_ALLOC_UNSUPPORTED();
   test_kernel_execution(FUNCTION, true, true);
 }
 

--- a/conformance_tests/core/test_module/src/test_module.cpp
+++ b/conformance_tests/core/test_module/src/test_module.cpp
@@ -1215,7 +1215,7 @@ protected:
 void zeKernelLaunchTests::test_kernel_execution(enum TestType test_type,
                                                 const bool is_immediate,
                                                 bool is_shared_system) {
-  lzt::gtest_skip_if_shared_system_alloc_unsupported(is_shared_system);
+  SKIP_IF_SHARED_SYSTEM_ALLOC_UNSUPPORTED(is_shared_system);
 
   ze_device_compute_properties_t dev_compute_properties = {};
   dev_compute_properties.stype = ZE_STRUCTURE_TYPE_DEVICE_COMPUTE_PROPERTIES;

--- a/conformance_tests/core/test_residency/src/test_residency.cpp
+++ b/conformance_tests/core/test_residency/src/test_residency.cpp
@@ -188,10 +188,7 @@ TEST_F(
       GTEST_SKIP();
     }
 
-    auto mem_access_props = lzt::get_memory_access_properties(device);
-    auto systemMemSupported = mem_access_props.sharedSystemAllocCapabilities &
-                              ZE_MEMORY_ACCESS_CAP_FLAG_RW;
-    if (!systemMemSupported) {
+    if (!lzt::supports_shared_system_alloc(device)) {
       FAIL() << "ZE_RESULT_ERROR_UNSUPPORTED_FEATURE - Device does not support "
                 "system memory";
     }
@@ -363,10 +360,7 @@ void RunGivenSharedSystemMemoryWhenMakingMemoryResidentUsingKernelFlagTest(
       GTEST_SKIP();
     }
 
-    auto mem_access_props = lzt::get_memory_access_properties(device);
-    auto systemMemSupported = mem_access_props.sharedSystemAllocCapabilities &
-                              ZE_MEMORY_ACCESS_CAP_FLAG_RW;
-    if (!systemMemSupported) {
+    if (!lzt::supports_shared_system_alloc(device)) {
       FAIL() << "ZE_RESULT_ERROR_UNSUPPORTED_FEATURE - Device does not support "
                 "system memory";
     }

--- a/utils/test_harness/include/test_harness/test_harness_memory.hpp
+++ b/utils/test_harness/include/test_harness/test_harness_memory.hpp
@@ -223,7 +223,5 @@ inline bool supports_shared_system_alloc(bool is_shared_system) {
   return (is_shared_system && supports_shared_system_alloc());
 }
 
-// void gtest_skip_if_shared_system_alloc_unsupported(bool is_shared_system);
-
 }; // namespace level_zero_tests
 #endif

--- a/utils/test_harness/include/test_harness/test_harness_memory.hpp
+++ b/utils/test_harness/include/test_harness/test_harness_memory.hpp
@@ -219,11 +219,5 @@ inline bool supports_shared_system_alloc() {
   return supports_shared_system_alloc(get_default_driver());
 }
 
-inline bool supports_shared_system_alloc(bool is_shared_system) {
-  return (is_shared_system && supports_shared_system_alloc());
-}
-
-// void gtest_skip_if_shared_system_alloc_unsupported(bool is_shared_system);
-
 }; // namespace level_zero_tests
 #endif

--- a/utils/test_harness/include/test_harness/test_harness_memory.hpp
+++ b/utils/test_harness/include/test_harness/test_harness_memory.hpp
@@ -13,11 +13,13 @@
 #include "utils/utils.hpp"
 #include "gtest/gtest.h"
 
-#define SKIP_IF_SHARED_SYSTEM_ALLOC_UNSUPPORTED()              \
-  if (!level_zero_tests::supports_shared_system_alloc()) {     \
-    GTEST_SKIP() << "Device does not support shared system "                   \
-                    "allocation, skipping the test";                           \
-  }
+#define SKIP_IF_SHARED_SYSTEM_ALLOC_UNSUPPORTED()                              \
+  do {                                                                         \
+    if (!level_zero_tests::supports_shared_system_alloc()) {                   \
+      GTEST_SKIP() << "Device does not support shared system "                 \
+                      "allocation, skipping the test";                         \
+    }                                                                          \
+  } while (0)
 
 namespace level_zero_tests {
 

--- a/utils/test_harness/include/test_harness/test_harness_memory.hpp
+++ b/utils/test_harness/include/test_harness/test_harness_memory.hpp
@@ -13,8 +13,8 @@
 #include "utils/utils.hpp"
 #include "gtest/gtest.h"
 
-#define SKIP_IF_SHARED_SYSTEM_ALLOC_UNSUPPORTED(is_shared_system)              \
-  if (!level_zero_tests::supports_shared_system_alloc(is_shared_system)) {     \
+#define SKIP_IF_SHARED_SYSTEM_ALLOC_UNSUPPORTED()              \
+  if (!level_zero_tests::supports_shared_system_alloc()) {     \
     GTEST_SKIP() << "Device does not support shared system "                   \
                     "allocation, skipping the test";                           \
   }
@@ -222,6 +222,8 @@ inline bool supports_shared_system_alloc() {
 inline bool supports_shared_system_alloc(bool is_shared_system) {
   return (is_shared_system && supports_shared_system_alloc());
 }
+
+// void gtest_skip_if_shared_system_alloc_unsupported(bool is_shared_system);
 
 }; // namespace level_zero_tests
 #endif

--- a/utils/test_harness/src/test_harness_memory.cpp
+++ b/utils/test_harness/src/test_harness_memory.cpp
@@ -607,44 +607,4 @@ size_t create_page_aligned_size(size_t requested_size, size_t page_size) {
   }
 }
 
-// bool supports_shared_system_alloc(const ze_device_memory_access_properties_t &access) {
-//   const auto alloc_cap = access.sharedSystemAllocCapabilities;
-//   return (alloc_cap & ZE_MEMORY_ACCESS_CAP_FLAG_RW) != 0;
-// }
-
-// bool supports_shared_system_alloc(const ze_device_handle_t device) {
-//   return supports_shared_system_alloc(get_memory_access_properties(device));
-// }
-
-// bool supports_shared_system_alloc(const ze_driver_handle_t driver) {
-//   return supports_shared_system_alloc(get_default_device(driver));
-// }
-
-// bool supports_shared_system_alloc() {
-//   return supports_shared_system_alloc(get_default_driver());
-// }
-
-// bool supports_shared_system_alloc(bool is_shared_system) {
-//   return (is_shared_system && supports_shared_system_alloc());
-// }
-
-// bool supports_shared_system_alloc() {
-//   const auto device = lzt::get_default_device(lzt::get_default_driver());
-//   const auto access = lzt::get_memory_access_properties(device);
-//   return (access.sharedSystemAllocCapabilities & ZE_MEMORY_ACCESS_CAP_FLAG_RW) != 0;
-// }
-
-// void gtest_skip_if_shared_system_alloc_unsupported(bool is_shared_system) {
-//   if (is_shared_system) {
-//     const auto memory_access_properties = lzt::get_memory_access_properties(
-//         lzt::get_default_device(lzt::get_default_driver()));
-
-//     if ((memory_access_properties.sharedSystemAllocCapabilities &
-//          ZE_MEMORY_ACCESS_CAP_FLAG_RW) == 0) {
-//       GTEST_SKIP() << "device does not support shared system allocation, "
-//                       "skipping the test";
-//     }
-//   }
-// }
-
 }; // namespace level_zero_tests

--- a/utils/test_harness/src/test_harness_memory.cpp
+++ b/utils/test_harness/src/test_harness_memory.cpp
@@ -607,17 +607,44 @@ size_t create_page_aligned_size(size_t requested_size, size_t page_size) {
   }
 }
 
-void gtest_skip_if_shared_system_alloc_unsupported(bool is_shared_system) {
-  if (is_shared_system) {
-    const auto memory_access_properties = lzt::get_memory_access_properties(
-        lzt::get_default_device(lzt::get_default_driver()));
+// bool supports_shared_system_alloc(const ze_device_memory_access_properties_t &access) {
+//   const auto alloc_cap = access.sharedSystemAllocCapabilities;
+//   return (alloc_cap & ZE_MEMORY_ACCESS_CAP_FLAG_RW) != 0;
+// }
 
-    if ((memory_access_properties.sharedSystemAllocCapabilities &
-         ZE_MEMORY_ACCESS_CAP_FLAG_RW) == 0) {
-      GTEST_SKIP() << "device does not support shared system allocation, "
-                      "skipping the test";
-    }
-  }
-}
+// bool supports_shared_system_alloc(const ze_device_handle_t device) {
+//   return supports_shared_system_alloc(get_memory_access_properties(device));
+// }
+
+// bool supports_shared_system_alloc(const ze_driver_handle_t driver) {
+//   return supports_shared_system_alloc(get_default_device(driver));
+// }
+
+// bool supports_shared_system_alloc() {
+//   return supports_shared_system_alloc(get_default_driver());
+// }
+
+// bool supports_shared_system_alloc(bool is_shared_system) {
+//   return (is_shared_system && supports_shared_system_alloc());
+// }
+
+// bool supports_shared_system_alloc() {
+//   const auto device = lzt::get_default_device(lzt::get_default_driver());
+//   const auto access = lzt::get_memory_access_properties(device);
+//   return (access.sharedSystemAllocCapabilities & ZE_MEMORY_ACCESS_CAP_FLAG_RW) != 0;
+// }
+
+// void gtest_skip_if_shared_system_alloc_unsupported(bool is_shared_system) {
+//   if (is_shared_system) {
+//     const auto memory_access_properties = lzt::get_memory_access_properties(
+//         lzt::get_default_device(lzt::get_default_driver()));
+
+//     if ((memory_access_properties.sharedSystemAllocCapabilities &
+//          ZE_MEMORY_ACCESS_CAP_FLAG_RW) == 0) {
+//       GTEST_SKIP() << "device does not support shared system allocation, "
+//                       "skipping the test";
+//     }
+//   }
+// }
 
 }; // namespace level_zero_tests


### PR DESCRIPTION
The function `gtest_skip_if_shared_system_alloc_unsupported` is supposed to exit a shared system allocation test if the system doesn't support shared system allocations. However, the `GTEST_SKIP` macro inside the function only returns from the function instead of exiting the test, thus continuing the rest of the test. 

This PR fixes this my replacing `gtest_skip_if_shared_system_alloc_unsupported` with a macro and adds some inline functions to streamline checks for shared system allocation support.

Related-To: [VLCLJ-2502](https://jira.devtools.intel.com/browse/VLCLJ-2502)