### PR TITLE
fix: set correct event descriptor signal in test_event

### DIFF
--- a/conformance_tests/core/test_event/src/test_event.cpp
+++ b/conformance_tests/core/test_event/src/test_event.cpp
@@ -794,6 +794,8 @@ protected:
     ev_desc.wait = std::get<0>(GetParam());
     for (int i = 0; i < n_events; i++) {
       ev_desc.index = i;
+      if (i == n_events - 1)
+        ev_desc.signal = ZE_EVENT_SCOPE_FLAG_HOST;
       ev[i] = lzt::create_event(ep, ev_desc);
     }
   }


### PR DESCRIPTION
Related-To: NEO-14632
Signed-off-by: Jaroslaw Warchulski <jaroslaw.warchulski@intel.com>