### PR TITLE
fix: rename socket

### DIFF
--- a/utils/net/include/net/test_ipc_comm.hpp
+++ b/utils/net/include/net/test_ipc_comm.hpp
@@ -43,7 +43,7 @@ template <typename T> void send_ipc_handle(const T &ipc_handle);
 
 // definition
 template <typename T> int receive_ipc_handle(char *data) {
-  const char *socket_path = "ipc_socket";
+  const char *socket_path = "/tmp/lzt_ipc_socket";
 
   struct sockaddr_un local_addr, remote_addr;
   local_addr.sun_family = AF_UNIX;
@@ -95,7 +95,7 @@ template <typename T> int receive_ipc_handle(char *data) {
 }
 
 template <typename T> void send_ipc_handle(const T &ipc_handle) {
-  const char *socket_path = "ipc_socket";
+  const char *socket_path = "/tmp/lzt_ipc_socket";
 
   struct sockaddr_un remote_addr;
   remote_addr.sun_family = AF_UNIX;

--- a/utils/net/src/test_ipc_comm.cpp
+++ b/utils/net/src/test_ipc_comm.cpp
@@ -17,8 +17,6 @@
 namespace level_zero_tests {
 
 #ifdef __linux__
-const char *socket_path = "ipc_socket";
-
 int read_fd_from_socket(int unix_socket, char *data) {
   // call recvmsg to receive the descriptor on the unix_socket
   int fd = -1;


### PR DESCRIPTION
* socket must be created in the accessible directory, the common practice is to use `/tmp`