### PR TITLE
Fix: Handling GTEST_FAIL logic for multi-device scenario for PSU, RAS and EVENTS modules

### DIFF
--- a/conformance_tests/sysman/test_sysman_events/src/test_sysman_events.cpp
+++ b/conformance_tests/sysman/test_sysman_events/src/test_sysman_events.cpp
@@ -24,11 +24,7 @@ namespace {
 class EventsZesTest : public lzt::ZesSysmanCtsClass {
 public:
   ze_driver_handle_t hDriver;
-<<<<<<< HEAD
-  bool is_events_supported = false;
-=======
   bool is_handles_available = false;
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
   uint32_t timeout;
   uint64_t timeoutEx;
   EventsZesTest() {
@@ -43,11 +39,7 @@ public:
 class EventsTest : public lzt::SysmanCtsClass {
 public:
   ze_driver_handle_t hDriver;
-<<<<<<< HEAD
-  bool is_events_supported = false;
-=======
   bool is_handles_available = false;
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
   uint32_t timeout;
   uint64_t timeoutEx;
   EventsTest() {
@@ -74,7 +66,7 @@ LZT_TEST_F(
     num_temp_sensors = lzt::get_temp_handle_count(device);
     if (num_temp_sensors > 0) {
       is_handles_available = true;
-      LOG_INFO << "Temperature handles are available on this device";
+      LOG_INFO << "Temperature handles are available on this device!";
       auto temp_handles = lzt::get_temp_handles(device, num_temp_sensors);
       for (auto temp_handle : temp_handles) {
         auto temp_properties = lzt::get_temp_properties(temp_handle);
@@ -103,12 +95,11 @@ LZT_TEST_F(
                                            ZES_EVENT_TYPE_FLAG_TEMP_THRESHOLD2;
       }
     } else {
-      LOG_INFO << "No temperature handles found for this devcie! ";
+      LOG_INFO << "No temperature handles found for this device!";
     }
   }
   if (!is_handles_available) {
-    FAIL() << "No temperature handles found on any of the devices! "
-           << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    FAIL() << "No temperature handles found on any of the devices!";
   }
   // If we registered to receive events on any devices, start listening now
   uint32_t num_device_events = 0;
@@ -459,15 +450,9 @@ LZT_TEST_F(
   for (auto device : devices) {
     uint32_t count = lzt::get_power_handle_count(device);
     if (count > 0) {
-<<<<<<< HEAD
-      is_events_supported = true;
-      LOG_INFO << "Events handles are available on this device!";
-=======
       is_handles_available = true;
       LOG_INFO << "Power handles are available on this device!";
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
       auto power_handles = lzt::get_power_handles(device, count);
-      ASSERT_EQ(power_handles.size(), count);
       for (auto power_handle : power_handles) {
         ASSERT_NE(nullptr, power_handle);
       }
@@ -488,21 +473,12 @@ LZT_TEST_F(
                             ZES_EVENT_TYPE_FLAG_ENERGY_THRESHOLD_CROSSED);
       }
     } else {
-<<<<<<< HEAD
-      LOG_INFO << "No events handles found for this device!";
-    }
-  }
-
-  if (!is_events_supported) {
-    FAIL() << "No events handles found on any of the devices!";
-=======
       LOG_INFO << "No power handles found for this device!";
     }
   }
 
   if (!is_handles_available) {
     FAIL() << "No power handles found on any of the devices!";
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
   }
 
   // If we registered to receive events on any devices, start listening now
@@ -528,15 +504,9 @@ LZT_TEST_F(
   for (auto device : devices) {
     uint32_t count = lzt::get_power_handle_count(device);
     if (count > 0) {
-<<<<<<< HEAD
-      is_events_supported = true;
-      LOG_INFO << "Events handles are available on this device!";
-=======
       is_handles_available = true;
       LOG_INFO << "Power handles are available on this device!";
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
       auto power_handles = lzt::get_power_handles(device, count);
-      ASSERT_EQ(power_handles.size(), count);
       for (auto power_handle : power_handles) {
         ASSERT_NE(nullptr, power_handle);
       }
@@ -557,19 +527,11 @@ LZT_TEST_F(
                             ZES_EVENT_TYPE_FLAG_ENERGY_THRESHOLD_CROSSED);
       }
     } else {
-<<<<<<< HEAD
-      LOG_INFO << "No events handles found for this device!";
-    }
-  }
-  if (!is_events_supported) {
-    FAIL() << "No events handles found on any of the devices!";
-=======
       LOG_INFO << "No power handles found for this device!";
     }
   }
   if (!is_handles_available) {
     FAIL() << "No power handles found on any of the devices!";
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
   }
 
   // If we registered to receive events on any devices, start listening now
@@ -734,13 +696,8 @@ LZT_TEST_F(
     uint32_t count = 0;
     count = lzt::get_ras_handles_count(device);
     if (count > 0) {
-<<<<<<< HEAD
-      is_events_supported = true;
-      LOG_INFO << "Events handles are available on this device!";
-=======
       is_handles_available = true;
-      LOG_INFO << "RAS handles are available on this device!";
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
+      LOG_INFO << "Ras handles are available on this device!";
 
       auto ras_handles = lzt::get_ras_handles(device, count);
       for (auto ras_handle : ras_handles) {
@@ -766,19 +723,11 @@ LZT_TEST_F(
         lzt::register_event(device, setEvent);
       }
     } else {
-<<<<<<< HEAD
-      LOG_INFO << "No events handles are available on this device!";
-    }
-  }
-  if (!is_events_supported) {
-    FAIL() << "No Events handles are available on any device!";
-=======
-      LOG_INFO << "No ras handles found for this device!";
+      LOG_INFO << "No ras handles found on this device!";
     }
   }
   if (!is_handles_available) {
-    FAIL() << "No ras handles are available on any of the devices!";
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
+    FAIL() << "No ras handles found on any of the devices!";
   }
 
   // If we registered to receive events on any devices, start listening now
@@ -808,13 +757,8 @@ LZT_TEST_F(
     uint32_t count = 0;
     count = lzt::get_ras_handles_count(device);
     if (count > 0) {
-<<<<<<< HEAD
-      is_events_supported = true;
-      LOG_INFO << "Events handles are available on this device!";
-=======
       is_handles_available = true;
-      LOG_INFO << "RAS handles are available on this device!";
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
+      LOG_INFO << "Ras handles are available on this device!";
       auto ras_handles = lzt::get_ras_handles(device, count);
       for (auto ras_handle : ras_handles) {
         auto props = lzt::get_ras_properties(ras_handle);
@@ -840,19 +784,11 @@ LZT_TEST_F(
         lzt::register_event(device, setEvent);
       }
     } else {
-<<<<<<< HEAD
-      LOG_INFO << "No events handles are available on this device!";
-    }
-  }
-  if (!is_events_supported) {
-    FAIL() << "No events handles are available on any device!";
-=======
-      LOG_INFO << "No ras handles found for this device!";
+      LOG_INFO << "No ras handles available on this device!";
     }
   }
   if (!is_handles_available) {
-    FAIL() << "No ras handles are found on any of the devices!";
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
+    FAIL() << "No ras handles found on any of the devices!";
   }
 
   // If we registered to receive events on any devices, start listening now

--- a/conformance_tests/sysman/test_sysman_events/src/test_sysman_events.cpp
+++ b/conformance_tests/sysman/test_sysman_events/src/test_sysman_events.cpp
@@ -24,7 +24,11 @@ namespace {
 class EventsZesTest : public lzt::ZesSysmanCtsClass {
 public:
   ze_driver_handle_t hDriver;
+<<<<<<< HEAD
   bool is_events_supported = false;
+=======
+  bool is_handles_available = false;
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
   uint32_t timeout;
   uint64_t timeoutEx;
   EventsZesTest() {
@@ -39,7 +43,11 @@ public:
 class EventsTest : public lzt::SysmanCtsClass {
 public:
   ze_driver_handle_t hDriver;
+<<<<<<< HEAD
   bool is_events_supported = false;
+=======
+  bool is_handles_available = false;
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
   uint32_t timeout;
   uint64_t timeoutEx;
   EventsTest() {
@@ -63,36 +71,44 @@ LZT_TEST_F(
     GivenValidEventHandleWhenListeningTemperatureEventsForCriticalOrThresholdTempThenEventsAreTriggered) {
   for (auto device : devices) {
     uint32_t num_temp_sensors = 0;
-    auto temp_handles = lzt::get_temp_handles(device, num_temp_sensors);
-    if (num_temp_sensors == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    num_temp_sensors = lzt::get_temp_handle_count(device);
+    if (num_temp_sensors > 0) {
+      is_handles_available = true;
+      LOG_INFO << "Temperature handles are available on this device";
+      auto temp_handles = lzt::get_temp_handles(device, num_temp_sensors);
+      for (auto temp_handle : temp_handles) {
+        auto temp_properties = lzt::get_temp_properties(temp_handle);
+        auto temp_config = lzt::get_temp_config(temp_handle);
+        auto tempLimit = lzt::get_temp_state(temp_handle);
+        if (temp_properties.isCriticalTempSupported) {
+          temp_config.enableCritical = true;
+        }
+        if (temp_properties.isThreshold1Supported) {
+          temp_config.threshold1.enableHighToLow = false;
+          temp_config.threshold1.enableLowToHigh = true;
+          // Setting threshold couple of degree above the current temperature
+          temp_config.threshold1.threshold = tempLimit + 2;
+          temp_config.threshold2.enableHighToLow = false;
+          temp_config.threshold2.enableLowToHigh = false;
+        }
+        if ((temp_properties.isCriticalTempSupported == false) ||
+            (temp_properties.isThreshold1Supported == false)) {
+          // continue, as HW is not supporting the events
+          continue;
+        }
+        ASSERT_ZE_RESULT_SUCCESS(
+            lzt::set_temp_config(temp_handle, temp_config));
+        zes_event_type_flags_t setEvents = ZES_EVENT_TYPE_FLAG_TEMP_CRITICAL |
+                                           ZES_EVENT_TYPE_FLAG_TEMP_THRESHOLD1 |
+                                           ZES_EVENT_TYPE_FLAG_TEMP_THRESHOLD2;
+      }
+    } else {
+      LOG_INFO << "No temperature handles found for this devcie! ";
     }
-    for (auto temp_handle : temp_handles) {
-      auto temp_properties = lzt::get_temp_properties(temp_handle);
-      auto temp_config = lzt::get_temp_config(temp_handle);
-      auto tempLimit = lzt::get_temp_state(temp_handle);
-      if (temp_properties.isCriticalTempSupported) {
-        temp_config.enableCritical = true;
-      }
-      if (temp_properties.isThreshold1Supported) {
-        temp_config.threshold1.enableHighToLow = false;
-        temp_config.threshold1.enableLowToHigh = true;
-        // Setting threshold couple of degree above the current temperature
-        temp_config.threshold1.threshold = tempLimit + 2;
-        temp_config.threshold2.enableHighToLow = false;
-        temp_config.threshold2.enableLowToHigh = false;
-      }
-      if ((temp_properties.isCriticalTempSupported == false) ||
-          (temp_properties.isThreshold1Supported == false)) {
-        // continue, as HW is not supporting the events
-        continue;
-      }
-      ASSERT_ZE_RESULT_SUCCESS(lzt::set_temp_config(temp_handle, temp_config));
-      zes_event_type_flags_t setEvents = ZES_EVENT_TYPE_FLAG_TEMP_CRITICAL |
-                                         ZES_EVENT_TYPE_FLAG_TEMP_THRESHOLD1 |
-                                         ZES_EVENT_TYPE_FLAG_TEMP_THRESHOLD2;
-    }
+  }
+  if (!is_handles_available) {
+    FAIL() << "No temperature handles found on any of the devices! "
+           << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
   // If we registered to receive events on any devices, start listening now
   uint32_t num_device_events = 0;
@@ -443,8 +459,13 @@ LZT_TEST_F(
   for (auto device : devices) {
     uint32_t count = lzt::get_power_handle_count(device);
     if (count > 0) {
+<<<<<<< HEAD
       is_events_supported = true;
       LOG_INFO << "Events handles are available on this device!";
+=======
+      is_handles_available = true;
+      LOG_INFO << "Power handles are available on this device!";
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
       auto power_handles = lzt::get_power_handles(device, count);
       ASSERT_EQ(power_handles.size(), count);
       for (auto power_handle : power_handles) {
@@ -467,12 +488,21 @@ LZT_TEST_F(
                             ZES_EVENT_TYPE_FLAG_ENERGY_THRESHOLD_CROSSED);
       }
     } else {
+<<<<<<< HEAD
       LOG_INFO << "No events handles found for this device!";
     }
   }
 
   if (!is_events_supported) {
     FAIL() << "No events handles found on any of the devices!";
+=======
+      LOG_INFO << "No power handles found for this device!";
+    }
+  }
+
+  if (!is_handles_available) {
+    FAIL() << "No power handles found on any of the devices!";
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
   }
 
   // If we registered to receive events on any devices, start listening now
@@ -498,8 +528,13 @@ LZT_TEST_F(
   for (auto device : devices) {
     uint32_t count = lzt::get_power_handle_count(device);
     if (count > 0) {
+<<<<<<< HEAD
       is_events_supported = true;
       LOG_INFO << "Events handles are available on this device!";
+=======
+      is_handles_available = true;
+      LOG_INFO << "Power handles are available on this device!";
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
       auto power_handles = lzt::get_power_handles(device, count);
       ASSERT_EQ(power_handles.size(), count);
       for (auto power_handle : power_handles) {
@@ -522,11 +557,19 @@ LZT_TEST_F(
                             ZES_EVENT_TYPE_FLAG_ENERGY_THRESHOLD_CROSSED);
       }
     } else {
+<<<<<<< HEAD
       LOG_INFO << "No events handles found for this device!";
     }
   }
   if (!is_events_supported) {
     FAIL() << "No events handles found on any of the devices!";
+=======
+      LOG_INFO << "No power handles found for this device!";
+    }
+  }
+  if (!is_handles_available) {
+    FAIL() << "No power handles found on any of the devices!";
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
   }
 
   // If we registered to receive events on any devices, start listening now
@@ -691,8 +734,13 @@ LZT_TEST_F(
     uint32_t count = 0;
     count = lzt::get_ras_handles_count(device);
     if (count > 0) {
+<<<<<<< HEAD
       is_events_supported = true;
       LOG_INFO << "Events handles are available on this device!";
+=======
+      is_handles_available = true;
+      LOG_INFO << "RAS handles are available on this device!";
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
 
       auto ras_handles = lzt::get_ras_handles(device, count);
       for (auto ras_handle : ras_handles) {
@@ -718,11 +766,19 @@ LZT_TEST_F(
         lzt::register_event(device, setEvent);
       }
     } else {
+<<<<<<< HEAD
       LOG_INFO << "No events handles are available on this device!";
     }
   }
   if (!is_events_supported) {
     FAIL() << "No Events handles are available on any device!";
+=======
+      LOG_INFO << "No ras handles found for this device!";
+    }
+  }
+  if (!is_handles_available) {
+    FAIL() << "No ras handles are available on any of the devices!";
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
   }
 
   // If we registered to receive events on any devices, start listening now
@@ -752,8 +808,13 @@ LZT_TEST_F(
     uint32_t count = 0;
     count = lzt::get_ras_handles_count(device);
     if (count > 0) {
+<<<<<<< HEAD
       is_events_supported = true;
       LOG_INFO << "Events handles are available on this device!";
+=======
+      is_handles_available = true;
+      LOG_INFO << "RAS handles are available on this device!";
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
       auto ras_handles = lzt::get_ras_handles(device, count);
       for (auto ras_handle : ras_handles) {
         auto props = lzt::get_ras_properties(ras_handle);
@@ -779,11 +840,19 @@ LZT_TEST_F(
         lzt::register_event(device, setEvent);
       }
     } else {
+<<<<<<< HEAD
       LOG_INFO << "No events handles are available on this device!";
     }
   }
   if (!is_events_supported) {
     FAIL() << "No events handles are available on any device!";
+=======
+      LOG_INFO << "No ras handles found for this device!";
+    }
+  }
+  if (!is_handles_available) {
+    FAIL() << "No ras handles are found on any of the devices!";
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
   }
 
   // If we registered to receive events on any devices, start listening now

--- a/conformance_tests/sysman/test_sysman_psu/src/test_sysman_psu.cpp
+++ b/conformance_tests/sysman/test_sysman_psu/src/test_sysman_psu.cpp
@@ -19,10 +19,16 @@ namespace lzt = level_zero_tests;
 namespace {
 
 #ifdef USE_ZESINIT
-class PsuModuleZesTest : public lzt::ZesSysmanCtsClass {};
+class PsuModuleZesTest : public lzt::ZesSysmanCtsClass {
+public:
+  bool is_psu_supported = false;
+};
 #define PSU_TEST PsuModuleZesTest
 #else // USE_ZESINIT
-class PsuModuleTest : public lzt::SysmanCtsClass {};
+class PsuModuleTest : public lzt::SysmanCtsClass {
+public:
+  bool is_psu_supported = false;
+};
 #define PSU_TEST PsuModuleTest
 #endif // USE_ZESINIT
 
@@ -39,16 +45,22 @@ LZT_TEST_F(
     GivenComponentCountZeroWhenRetrievingSysmanHandlesThenNotNullPsuHandlesAreReturned) {
   for (auto device : devices) {
     uint32_t count = 0;
-    auto psu_handles = lzt::get_psu_handles(device, count);
-    ASSERT_EQ(psu_handles.size(), count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    count = lzt::get_psu_handles_count(device);
+    if (count > 0) {
+      is_psu_supported = true;
+      LOG_INFO << "PSU handles are available on this device!";
+      auto psu_handles = lzt::get_psu_handles(device, count);
+      ASSERT_EQ(psu_handles.size(), count);
+      for (auto psu_handle : psu_handles) {
+        ASSERT_NE(nullptr, psu_handle);
+      }
+    } else {
+      LOG_INFO << "PSU handles are not available on this device!";
     }
-
-    for (auto psu_handle : psu_handles) {
-      ASSERT_NE(nullptr, psu_handle);
-    }
+  }
+  if (!is_psu_supported) {
+    FAIL() << "No psu handles found: "
+           << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
 
@@ -57,15 +69,21 @@ LZT_TEST_F(
     GivenInvalidComponentCountWhenRetrievingSysmanHandlesThenActualComponentCountIsUpdated) {
   for (auto device : devices) {
     uint32_t actual_count = 0;
-    lzt::get_psu_handles(device, actual_count);
-    if (actual_count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    actual_count = lzt::get_psu_handles_count(device);
+    if (actual_count > 0) {
+      is_psu_supported = true;
+      LOG_INFO << "PSU handles are available on this device!";
+      lzt::get_psu_handles(device, actual_count);
+      uint32_t test_count = actual_count + 1;
+      lzt::get_psu_handles(device, test_count);
+      EXPECT_EQ(test_count, actual_count);
+    } else {
+      LOG_INFO << "PSU handles are not available on this device!";
     }
-
-    uint32_t test_count = actual_count + 1;
-    lzt::get_psu_handles(device, test_count);
-    EXPECT_EQ(test_count, actual_count);
+  }
+  if (!is_psu_supported) {
+    FAIL() << "No psu handles found: "
+           << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
 
@@ -74,23 +92,26 @@ LZT_TEST_F(
     GivenValidComponentCountWhenCallingApiTwiceThenSimilarMemHandlesReturned) {
   for (auto device : devices) {
     uint32_t count = 0;
-    auto psu_handles_initial = lzt::get_psu_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    count = lzt::get_psu_handles_count(device);
+    if (count > 0) {
+      is_psu_supported = true;
+      LOG_INFO << "PSU handles are available on this device!";
+      auto psu_handles_initial = lzt::get_psu_handles(device, count);
+      for (auto psu_handle : psu_handles_initial) {
+        ASSERT_NE(nullptr, psu_handle);
+      }
+      auto psu_handles_later = lzt::get_psu_handles(device, count);
+      for (auto psu_handle : psu_handles_later) {
+        ASSERT_NE(nullptr, psu_handle);
+      }
+      EXPECT_EQ(psu_handles_initial, psu_handles_later);
+    } else {
+      LOG_INFO << "PSU handles are not available on this device!";
     }
-
-    for (auto psu_handle : psu_handles_initial) {
-      ASSERT_NE(nullptr, psu_handle);
-    }
-
-    count = 0;
-    auto psu_handles_later = lzt::get_psu_handles(device, count);
-    for (auto psu_handle : psu_handles_later) {
-      ASSERT_NE(nullptr, psu_handle);
-    }
-
-    EXPECT_EQ(psu_handles_initial, psu_handles_later);
+  }
+  if (!is_psu_supported) {
+    FAIL() << "No psu devices found: "
+           << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
 LZT_TEST_F(
@@ -99,20 +120,26 @@ LZT_TEST_F(
   for (auto device : devices) {
     auto deviceProperties = lzt::get_sysman_device_properties(device);
     uint32_t count = 0;
-    auto psu_handles = lzt::get_psu_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
-    }
-
-    for (auto psu_handle : psu_handles) {
-      ASSERT_NE(nullptr, psu_handle);
-      auto properties = lzt::get_psu_properties(psu_handle);
-      EXPECT_LE(properties.ampLimit, UINT32_MAX);
-      if (properties.onSubdevice) {
-        EXPECT_LT(properties.subdeviceId, deviceProperties.numSubdevices);
+    count = lzt::get_psu_handles_count(device);
+    if (count > 0) {
+      is_psu_supported = true;
+      LOG_INFO << "PSU handles are available on this device!";
+      auto psu_handles = lzt::get_psu_handles(device, count);
+      for (auto psu_handle : psu_handles) {
+        ASSERT_NE(nullptr, psu_handle);
+        auto properties = lzt::get_psu_properties(psu_handle);
+        EXPECT_LE(properties.ampLimit, UINT32_MAX);
+        if (properties.onSubdevice) {
+          EXPECT_LT(properties.subdeviceId, deviceProperties.numSubdevices);
+        }
       }
+    } else {
+      LOG_INFO << "PSU handles are not available on this device!";
     }
+  }
+  if (!is_psu_supported) {
+    FAIL() << "No psu handles found: "
+           << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
 
@@ -121,44 +148,56 @@ LZT_TEST_F(
     GivenValidPsuHandleWhenRetrievingPsuPropertiesThenExpectSamePropertiesReturnedTwice) {
   for (auto device : devices) {
     uint32_t count = 0;
-    auto psu_handles = lzt::get_psu_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
-    }
-
-    for (auto psu_handle : psu_handles) {
-      ASSERT_NE(nullptr, psu_handle);
-      auto properties_initial = lzt::get_psu_properties(psu_handle);
-      auto properties_later = lzt::get_psu_properties(psu_handle);
-      EXPECT_EQ(properties_initial.haveFan, properties_later.haveFan);
-      EXPECT_EQ(properties_initial.onSubdevice, properties_later.onSubdevice);
-      EXPECT_EQ(properties_initial.subdeviceId, properties_later.subdeviceId);
-
-      EXPECT_EQ(properties_initial.ampLimit, properties_later.ampLimit);
+    count = lzt::get_psu_handles_count(device);
+    if (count > 0) {
+      is_psu_supported = true;
+      LOG_INFO << "PSU handles are available on this device!";
+      auto psu_handles = lzt::get_psu_handles(device, count);
+      for (auto psu_handle : psu_handles) {
+        ASSERT_NE(nullptr, psu_handle);
+        auto properties_initial = lzt::get_psu_properties(psu_handle);
+        auto properties_later = lzt::get_psu_properties(psu_handle);
+        EXPECT_EQ(properties_initial.haveFan, properties_later.haveFan);
+        EXPECT_EQ(properties_initial.onSubdevice, properties_later.onSubdevice);
+        EXPECT_EQ(properties_initial.subdeviceId, properties_later.subdeviceId);
+        EXPECT_EQ(properties_initial.ampLimit, properties_later.ampLimit);
+      }
+    } else {
+      LOG_INFO << "PSU handles are not available on this device!";
     }
   }
+  if (!is_psu_supported) {
+    FAIL() << "No psu handles found: "
+           << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+  }
 }
+
 LZT_TEST_F(PSU_TEST,
            GivenValidPsuHandleWhenRetrievingPsuStateThenValidStateIsReturned) {
   for (auto device : devices) {
     uint32_t count = 0;
-    auto psu_handles = lzt::get_psu_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    count = lzt::get_psu_handles_count(device);
+    if (count > 0) {
+      is_psu_supported = true;
+      LOG_INFO << "PSU handles are available on this device!";
+      auto psu_handles = lzt::get_psu_handles(device, count);
+      for (auto psu_handle : psu_handles) {
+        ASSERT_NE(nullptr, psu_handle);
+        auto state = lzt::get_psu_state(psu_handle);
+        EXPECT_GE(state.voltStatus, ZES_PSU_VOLTAGE_STATUS_UNKNOWN);
+        EXPECT_LE(state.voltStatus, ZES_PSU_VOLTAGE_STATUS_UNDER);
+        EXPECT_LE(state.temperature, UINT32_MAX);
+        EXPECT_LE(state.current, UINT32_MAX);
+        auto properties = lzt::get_psu_properties(psu_handle);
+        EXPECT_LE(state.current, properties.ampLimit);
+      }
+    } else {
+      LOG_INFO << "PSU handles are not available on this device!";
     }
-
-    for (auto psu_handle : psu_handles) {
-      ASSERT_NE(nullptr, psu_handle);
-      auto state = lzt::get_psu_state(psu_handle);
-      EXPECT_GE(state.voltStatus, ZES_PSU_VOLTAGE_STATUS_UNKNOWN);
-      EXPECT_LE(state.voltStatus, ZES_PSU_VOLTAGE_STATUS_UNDER);
-      EXPECT_LE(state.temperature, UINT32_MAX);
-      EXPECT_LE(state.current, UINT32_MAX);
-      auto properties = lzt::get_psu_properties(psu_handle);
-      EXPECT_LE(state.current, properties.ampLimit);
-    }
+  }
+  if (!is_psu_supported) {
+    FAIL() << "No psu handles found: "
+           << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
 } // namespace

--- a/conformance_tests/sysman/test_sysman_psu/src/test_sysman_psu.cpp
+++ b/conformance_tests/sysman/test_sysman_psu/src/test_sysman_psu.cpp
@@ -55,20 +55,11 @@ LZT_TEST_F(
         ASSERT_NE(nullptr, psu_handle);
       }
     } else {
-<<<<<<< HEAD
-      LOG_INFO << "PSU handles are not available on this device!";
+      LOG_INFO << "No psu handles found for this device!";
     }
   }
   if (!is_psu_supported) {
-    FAIL() << "No psu handles found: "
-=======
-      LOG_INFO << "No psu handles are found for this device!";
-    }
-  }
-  if (!is_psu_supported) {
-    FAIL() << "No psu handles found on any of the devices! "
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
-           << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    FAIL() << "No psu handles found on any of the devices!";
   }
 }
 
@@ -86,20 +77,11 @@ LZT_TEST_F(
       lzt::get_psu_handles(device, test_count);
       EXPECT_EQ(test_count, actual_count);
     } else {
-<<<<<<< HEAD
-      LOG_INFO << "PSU handles are not available on this device!";
+      LOG_INFO << "No psu handles found for this device!";
     }
   }
   if (!is_psu_supported) {
-    FAIL() << "No psu handles found: "
-=======
-      LOG_INFO << "No psu handles are found for this device!";
-    }
-  }
-  if (!is_psu_supported) {
-    FAIL() << "No psu handles found on any of the devices! "
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
-           << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    FAIL() << "No psu handles found on any of the devices!";
   }
 }
 
@@ -116,26 +98,18 @@ LZT_TEST_F(
       for (auto psu_handle : psu_handles_initial) {
         ASSERT_NE(nullptr, psu_handle);
       }
+      count = 0;
       auto psu_handles_later = lzt::get_psu_handles(device, count);
       for (auto psu_handle : psu_handles_later) {
         ASSERT_NE(nullptr, psu_handle);
       }
       EXPECT_EQ(psu_handles_initial, psu_handles_later);
     } else {
-<<<<<<< HEAD
-      LOG_INFO << "PSU handles are not available on this device!";
+      LOG_INFO << "No psu handles found for this device!";
     }
   }
   if (!is_psu_supported) {
-    FAIL() << "No psu devices found: "
-=======
-      LOG_INFO << "No psu handles are found for this device!";
-    }
-  }
-  if (!is_psu_supported) {
-    FAIL() << "No psu handles found on any of the devices! "
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
-           << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    FAIL() << "No psu handles found on any of the devices!";
   }
 }
 LZT_TEST_F(
@@ -158,20 +132,11 @@ LZT_TEST_F(
         }
       }
     } else {
-<<<<<<< HEAD
-      LOG_INFO << "PSU handles are not available on this device!";
+      LOG_INFO << "No psu handles found for this device!";
     }
   }
   if (!is_psu_supported) {
-    FAIL() << "No psu handles found: "
-=======
-      LOG_INFO << "No psu handles are found for this device!";
-    }
-  }
-  if (!is_psu_supported) {
-    FAIL() << "No psu handles found on any of the devices! "
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
-           << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    FAIL() << "No psu handles found on any of the devices!";
   }
 }
 
@@ -195,20 +160,11 @@ LZT_TEST_F(
         EXPECT_EQ(properties_initial.ampLimit, properties_later.ampLimit);
       }
     } else {
-<<<<<<< HEAD
-      LOG_INFO << "PSU handles are not available on this device!";
+      LOG_INFO << "No psu handles found for this device!";
     }
   }
   if (!is_psu_supported) {
-    FAIL() << "No psu handles found: "
-=======
-      LOG_INFO << "No psu handles are found for this device!";
-    }
-  }
-  if (!is_psu_supported) {
-    FAIL() << "No psu handles found on any of the devices! "
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
-           << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    FAIL() << "No psu handles found on any of the devices!";
   }
 }
 
@@ -232,20 +188,11 @@ LZT_TEST_F(PSU_TEST,
         EXPECT_LE(state.current, properties.ampLimit);
       }
     } else {
-<<<<<<< HEAD
-      LOG_INFO << "PSU handles are not available on this device!";
+      LOG_INFO << "No psu handles found for this device!";
     }
   }
   if (!is_psu_supported) {
-    FAIL() << "No psu handles found: "
-=======
-      LOG_INFO << "No psu handles are found for this device!";
-    }
-  }
-  if (!is_psu_supported) {
-    FAIL() << "No psu handles found on any of the devices! "
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
-           << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    FAIL() << "No psu handles found on any of the devices!";
   }
 }
 } // namespace

--- a/conformance_tests/sysman/test_sysman_psu/src/test_sysman_psu.cpp
+++ b/conformance_tests/sysman/test_sysman_psu/src/test_sysman_psu.cpp
@@ -55,11 +55,19 @@ LZT_TEST_F(
         ASSERT_NE(nullptr, psu_handle);
       }
     } else {
+<<<<<<< HEAD
       LOG_INFO << "PSU handles are not available on this device!";
     }
   }
   if (!is_psu_supported) {
     FAIL() << "No psu handles found: "
+=======
+      LOG_INFO << "No psu handles are found for this device!";
+    }
+  }
+  if (!is_psu_supported) {
+    FAIL() << "No psu handles found on any of the devices! "
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
            << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
@@ -78,11 +86,19 @@ LZT_TEST_F(
       lzt::get_psu_handles(device, test_count);
       EXPECT_EQ(test_count, actual_count);
     } else {
+<<<<<<< HEAD
       LOG_INFO << "PSU handles are not available on this device!";
     }
   }
   if (!is_psu_supported) {
     FAIL() << "No psu handles found: "
+=======
+      LOG_INFO << "No psu handles are found for this device!";
+    }
+  }
+  if (!is_psu_supported) {
+    FAIL() << "No psu handles found on any of the devices! "
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
            << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
@@ -106,11 +122,19 @@ LZT_TEST_F(
       }
       EXPECT_EQ(psu_handles_initial, psu_handles_later);
     } else {
+<<<<<<< HEAD
       LOG_INFO << "PSU handles are not available on this device!";
     }
   }
   if (!is_psu_supported) {
     FAIL() << "No psu devices found: "
+=======
+      LOG_INFO << "No psu handles are found for this device!";
+    }
+  }
+  if (!is_psu_supported) {
+    FAIL() << "No psu handles found on any of the devices! "
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
            << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
@@ -134,11 +158,19 @@ LZT_TEST_F(
         }
       }
     } else {
+<<<<<<< HEAD
       LOG_INFO << "PSU handles are not available on this device!";
     }
   }
   if (!is_psu_supported) {
     FAIL() << "No psu handles found: "
+=======
+      LOG_INFO << "No psu handles are found for this device!";
+    }
+  }
+  if (!is_psu_supported) {
+    FAIL() << "No psu handles found on any of the devices! "
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
            << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
@@ -163,11 +195,19 @@ LZT_TEST_F(
         EXPECT_EQ(properties_initial.ampLimit, properties_later.ampLimit);
       }
     } else {
+<<<<<<< HEAD
       LOG_INFO << "PSU handles are not available on this device!";
     }
   }
   if (!is_psu_supported) {
     FAIL() << "No psu handles found: "
+=======
+      LOG_INFO << "No psu handles are found for this device!";
+    }
+  }
+  if (!is_psu_supported) {
+    FAIL() << "No psu handles found on any of the devices! "
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
            << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
@@ -192,11 +232,19 @@ LZT_TEST_F(PSU_TEST,
         EXPECT_LE(state.current, properties.ampLimit);
       }
     } else {
+<<<<<<< HEAD
       LOG_INFO << "PSU handles are not available on this device!";
     }
   }
   if (!is_psu_supported) {
     FAIL() << "No psu handles found: "
+=======
+      LOG_INFO << "No psu handles are found for this device!";
+    }
+  }
+  if (!is_psu_supported) {
+    FAIL() << "No psu handles found on any of the devices! "
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
            << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }

--- a/conformance_tests/sysman/test_sysman_ras/src/test_sysman_ras.cpp
+++ b/conformance_tests/sysman/test_sysman_ras/src/test_sysman_ras.cpp
@@ -181,20 +181,11 @@ LZT_TEST_F(
         lzt::set_ras_config(ras_handle, rasConfigOriginal);
       }
     } else {
-<<<<<<< HEAD
-      LOG_INFO << "RAS handles are not available on this device!";
-    }
-  }
-  if (!is_ras_supported) {
-    FAIL() << "No ras handles found: "
-=======
       LOG_INFO << "No ras handles found for this device!";
     }
   }
   if (!is_ras_supported) {
-    FAIL() << "No ras handles found on any of the devices! "
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
-           << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    FAIL() << "No ras handles found on any of the devices!";
   }
 }
 
@@ -215,20 +206,11 @@ LZT_TEST_F(RAS_TEST,
         validate_ras_state(rasState);
       }
     } else {
-<<<<<<< HEAD
-      LOG_INFO << "RAS handles are not available on this device!";
-    }
-  }
-  if (!is_ras_supported) {
-    FAIL() << "No ras handles found: "
-=======
       LOG_INFO << "No ras handles found for this device!";
     }
   }
   if (!is_ras_supported) {
-    FAIL() << "No ras handles found on any of the devices! "
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
-           << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    FAIL() << "No ras handles found on any of the devices!";
   }
 }
 
@@ -257,20 +239,11 @@ LZT_TEST_F(
         EXPECT_GE(tErrorsinitial, tErrorsAfterClear);
       }
     } else {
-<<<<<<< HEAD
-      LOG_INFO << "RAS handles are not available on this device!";
-    }
-  }
-  if (!is_ras_supported) {
-    FAIL() << "No ras handles found: "
-=======
       LOG_INFO << "No ras handles found for this device!";
     }
   }
   if (!is_ras_supported) {
-    FAIL() << "No ras handles found on any of the devices! "
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
-           << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    FAIL() << "No ras handles found on any of the devices!";
   }
 }
 
@@ -300,20 +273,11 @@ LZT_TEST_F(
         }
       }
     } else {
-<<<<<<< HEAD
-      LOG_INFO << "RAS handles are not available on this device!";
-    }
-  }
-  if (!is_ras_supported) {
-    FAIL() << "No ras handles found: "
-=======
       LOG_INFO << "No ras handles found for this device!";
     }
   }
   if (!is_ras_supported) {
-    FAIL() << "No ras handles found on any of the devices! "
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
-           << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    FAIL() << "No ras handles found on any of the devices!";
   }
 }
 
@@ -331,20 +295,11 @@ LZT_TEST_F(
         ASSERT_NE(nullptr, ras_handle);
       }
     } else {
-<<<<<<< HEAD
-      LOG_INFO << "RAS handles are not available on this device!";
-    }
-  }
-  if (!is_ras_supported) {
-    FAIL() << "No ras handles found: "
-=======
       LOG_INFO << "No ras handles found for this device!";
     }
   }
   if (!is_ras_supported) {
-    FAIL() << "No ras handles found on any of the devices! "
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
-           << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    FAIL() << "No ras handles found on any of the devices!";
   }
 }
 
@@ -356,11 +311,7 @@ LZT_TEST_F(
     count = lzt::get_ras_handles_count(device);
     if (count > 0) {
       is_ras_supported = true;
-<<<<<<< HEAD
       LOG_INFO << "RAS handles are  available on this device!";
-=======
-      LOG_INFO << "RAS handles are available on this device!";
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
       auto ras_handles = lzt::get_ras_handles(device, count);
       for (auto ras_handle : ras_handles) {
         ASSERT_NE(nullptr, ras_handle);
@@ -370,20 +321,11 @@ LZT_TEST_F(
         }
       }
     } else {
-<<<<<<< HEAD
-      LOG_INFO << "RAS handles are not available on this device!";
-    }
-  }
-  if (!is_ras_supported) {
-    FAIL() << "No ras handles found: "
-=======
       LOG_INFO << "No ras handles found for this device!";
     }
   }
   if (!is_ras_supported) {
-    FAIL() << "No ras handles found on any of the devices! "
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
-           << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    FAIL() << "No ras handles found on any of the devices!";
   }
 }
 
@@ -415,20 +357,11 @@ LZT_TEST_F(
         EXPECT_LE(errors_after_clear, initial_errors);
       }
     } else {
-<<<<<<< HEAD
-      LOG_INFO << "RAS handles are not available on this device!";
-    }
-  }
-  if (!is_ras_supported) {
-    FAIL() << "No ras devices found: "
-=======
       LOG_INFO << "No ras handles found for this device!";
     }
   }
   if (!is_ras_supported) {
-    FAIL() << "No ras handles found on any of the devices! "
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
-           << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    FAIL() << "No ras handles found on any of the devices!";
   }
 }
 } // namespace

--- a/conformance_tests/sysman/test_sysman_ras/src/test_sysman_ras.cpp
+++ b/conformance_tests/sysman/test_sysman_ras/src/test_sysman_ras.cpp
@@ -311,7 +311,7 @@ LZT_TEST_F(
     count = lzt::get_ras_handles_count(device);
     if (count > 0) {
       is_ras_supported = true;
-      LOG_INFO << "RAS handles are  available on this device!";
+      LOG_INFO << "RAS handles are available on this device!";
       auto ras_handles = lzt::get_ras_handles(device, count);
       for (auto ras_handle : ras_handles) {
         ASSERT_NE(nullptr, ras_handle);

--- a/conformance_tests/sysman/test_sysman_ras/src/test_sysman_ras.cpp
+++ b/conformance_tests/sysman/test_sysman_ras/src/test_sysman_ras.cpp
@@ -181,11 +181,19 @@ LZT_TEST_F(
         lzt::set_ras_config(ras_handle, rasConfigOriginal);
       }
     } else {
+<<<<<<< HEAD
       LOG_INFO << "RAS handles are not available on this device!";
     }
   }
   if (!is_ras_supported) {
     FAIL() << "No ras handles found: "
+=======
+      LOG_INFO << "No ras handles found for this device!";
+    }
+  }
+  if (!is_ras_supported) {
+    FAIL() << "No ras handles found on any of the devices! "
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
            << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
@@ -207,11 +215,19 @@ LZT_TEST_F(RAS_TEST,
         validate_ras_state(rasState);
       }
     } else {
+<<<<<<< HEAD
       LOG_INFO << "RAS handles are not available on this device!";
     }
   }
   if (!is_ras_supported) {
     FAIL() << "No ras handles found: "
+=======
+      LOG_INFO << "No ras handles found for this device!";
+    }
+  }
+  if (!is_ras_supported) {
+    FAIL() << "No ras handles found on any of the devices! "
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
            << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
@@ -241,11 +257,19 @@ LZT_TEST_F(
         EXPECT_GE(tErrorsinitial, tErrorsAfterClear);
       }
     } else {
+<<<<<<< HEAD
       LOG_INFO << "RAS handles are not available on this device!";
     }
   }
   if (!is_ras_supported) {
     FAIL() << "No ras handles found: "
+=======
+      LOG_INFO << "No ras handles found for this device!";
+    }
+  }
+  if (!is_ras_supported) {
+    FAIL() << "No ras handles found on any of the devices! "
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
            << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
@@ -276,11 +300,19 @@ LZT_TEST_F(
         }
       }
     } else {
+<<<<<<< HEAD
       LOG_INFO << "RAS handles are not available on this device!";
     }
   }
   if (!is_ras_supported) {
     FAIL() << "No ras handles found: "
+=======
+      LOG_INFO << "No ras handles found for this device!";
+    }
+  }
+  if (!is_ras_supported) {
+    FAIL() << "No ras handles found on any of the devices! "
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
            << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
@@ -299,11 +331,19 @@ LZT_TEST_F(
         ASSERT_NE(nullptr, ras_handle);
       }
     } else {
+<<<<<<< HEAD
       LOG_INFO << "RAS handles are not available on this device!";
     }
   }
   if (!is_ras_supported) {
     FAIL() << "No ras handles found: "
+=======
+      LOG_INFO << "No ras handles found for this device!";
+    }
+  }
+  if (!is_ras_supported) {
+    FAIL() << "No ras handles found on any of the devices! "
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
            << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
@@ -316,7 +356,11 @@ LZT_TEST_F(
     count = lzt::get_ras_handles_count(device);
     if (count > 0) {
       is_ras_supported = true;
+<<<<<<< HEAD
       LOG_INFO << "RAS handles are  available on this device!";
+=======
+      LOG_INFO << "RAS handles are available on this device!";
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
       auto ras_handles = lzt::get_ras_handles(device, count);
       for (auto ras_handle : ras_handles) {
         ASSERT_NE(nullptr, ras_handle);
@@ -326,11 +370,19 @@ LZT_TEST_F(
         }
       }
     } else {
+<<<<<<< HEAD
       LOG_INFO << "RAS handles are not available on this device!";
     }
   }
   if (!is_ras_supported) {
     FAIL() << "No ras handles found: "
+=======
+      LOG_INFO << "No ras handles found for this device!";
+    }
+  }
+  if (!is_ras_supported) {
+    FAIL() << "No ras handles found on any of the devices! "
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
            << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
@@ -363,11 +415,19 @@ LZT_TEST_F(
         EXPECT_LE(errors_after_clear, initial_errors);
       }
     } else {
+<<<<<<< HEAD
       LOG_INFO << "RAS handles are not available on this device!";
     }
   }
   if (!is_ras_supported) {
     FAIL() << "No ras devices found: "
+=======
+      LOG_INFO << "No ras handles found for this device!";
+    }
+  }
+  if (!is_ras_supported) {
+    FAIL() << "No ras handles found on any of the devices! "
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
            << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }

--- a/utils/test_harness/sysman/include/test_harness_sysman_ras.hpp
+++ b/utils/test_harness/sysman/include/test_harness_sysman_ras.hpp
@@ -12,7 +12,7 @@
 #include <level_zero/zes_api.h>
 #include "gtest/gtest.h"
 namespace level_zero_tests {
-
+uint32_t get_ras_handles_count(zes_device_handle_t device);
 std::vector<zes_ras_handle_t> get_ras_handles(zes_device_handle_t device,
                                               uint32_t &count);
 zes_ras_properties_t get_ras_properties(zes_ras_handle_t rasHandle);


### PR DESCRIPTION
Primary JIRA: [VLCJ-2513]
Sub-tasks: [VLCLJ-2574], [VLCLJ-2576], [VLCLJ-2567]

1. Updated the GTEST_FAIL logic for psu, ras and events modules. Implemented to check the handles for all the devices in multi-device scenario, and FAIL only if the handle is not found for any device.
2. Check the handles for each device and update the test to FAIL only if handles are not found for any device.