### PR TITLE
fix: calculate correct timestamp mask in case timestamp bitsequal size of timestamp type

### DIFF
--- a/perf_tests/ze_peak/src/ze_peak.cpp
+++ b/perf_tests/ze_peak/src/ze_peak.cpp
@@ -121,7 +121,8 @@ static void generic_uuid_to_string(const uint8_t *id, int bytes, char *s) {
 }
 
 template <typename T>
-static void calculate_timestamp_mask(T &timestamp_mask, uint32_t timestamp_bits) {
+static void calculate_timestamp_mask(T &timestamp_mask,
+                                     uint32_t timestamp_bits) {
   if (timestamp_bits >= sizeof(T) * CHAR_BIT) {
     timestamp_mask = std::numeric_limits<T>::max();
   } else {


### PR DESCRIPTION
Signed-off-by: Maciej Plewka <maciej.plewka@intel.com>