### PR TITLE
Fix: Handling GTEST_FAIL logic for multi-device scenario for LED, Memory and Firmware modules

### DIFF
--- a/conformance_tests/sysman/test_sysman_events/src/test_sysman_events.cpp
+++ b/conformance_tests/sysman/test_sysman_events/src/test_sysman_events.cpp
@@ -24,11 +24,7 @@ namespace {
 class EventsZesTest : public lzt::ZesSysmanCtsClass {
 public:
   ze_driver_handle_t hDriver;
-<<<<<<< HEAD
-  bool is_events_supported = false;
-=======
   bool is_handles_available = false;
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
   uint32_t timeout;
   uint64_t timeoutEx;
   EventsZesTest() {
@@ -43,11 +39,7 @@ public:
 class EventsTest : public lzt::SysmanCtsClass {
 public:
   ze_driver_handle_t hDriver;
-<<<<<<< HEAD
-  bool is_events_supported = false;
-=======
   bool is_handles_available = false;
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
   uint32_t timeout;
   uint64_t timeoutEx;
   EventsTest() {
@@ -74,7 +66,7 @@ LZT_TEST_F(
     num_temp_sensors = lzt::get_temp_handle_count(device);
     if (num_temp_sensors > 0) {
       is_handles_available = true;
-      LOG_INFO << "Temperature handles are available on this device";
+      LOG_INFO << "Temperature handles are available on this device!";
       auto temp_handles = lzt::get_temp_handles(device, num_temp_sensors);
       for (auto temp_handle : temp_handles) {
         auto temp_properties = lzt::get_temp_properties(temp_handle);
@@ -103,12 +95,11 @@ LZT_TEST_F(
                                            ZES_EVENT_TYPE_FLAG_TEMP_THRESHOLD2;
       }
     } else {
-      LOG_INFO << "No temperature handles found for this devcie! ";
+      LOG_INFO << "No temperature handles found for this device!";
     }
   }
   if (!is_handles_available) {
-    FAIL() << "No temperature handles found on any of the devices! "
-           << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    FAIL() << "No temperature handles found on any of the devices!";
   }
   // If we registered to receive events on any devices, start listening now
   uint32_t num_device_events = 0;
@@ -459,15 +450,9 @@ LZT_TEST_F(
   for (auto device : devices) {
     uint32_t count = lzt::get_power_handle_count(device);
     if (count > 0) {
-<<<<<<< HEAD
-      is_events_supported = true;
-      LOG_INFO << "Events handles are available on this device!";
-=======
       is_handles_available = true;
       LOG_INFO << "Power handles are available on this device!";
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
       auto power_handles = lzt::get_power_handles(device, count);
-      ASSERT_EQ(power_handles.size(), count);
       for (auto power_handle : power_handles) {
         ASSERT_NE(nullptr, power_handle);
       }
@@ -488,21 +473,12 @@ LZT_TEST_F(
                             ZES_EVENT_TYPE_FLAG_ENERGY_THRESHOLD_CROSSED);
       }
     } else {
-<<<<<<< HEAD
-      LOG_INFO << "No events handles found for this device!";
-    }
-  }
-
-  if (!is_events_supported) {
-    FAIL() << "No events handles found on any of the devices!";
-=======
       LOG_INFO << "No power handles found for this device!";
     }
   }
 
   if (!is_handles_available) {
     FAIL() << "No power handles found on any of the devices!";
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
   }
 
   // If we registered to receive events on any devices, start listening now
@@ -528,15 +504,9 @@ LZT_TEST_F(
   for (auto device : devices) {
     uint32_t count = lzt::get_power_handle_count(device);
     if (count > 0) {
-<<<<<<< HEAD
-      is_events_supported = true;
-      LOG_INFO << "Events handles are available on this device!";
-=======
       is_handles_available = true;
       LOG_INFO << "Power handles are available on this device!";
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
       auto power_handles = lzt::get_power_handles(device, count);
-      ASSERT_EQ(power_handles.size(), count);
       for (auto power_handle : power_handles) {
         ASSERT_NE(nullptr, power_handle);
       }
@@ -557,19 +527,11 @@ LZT_TEST_F(
                             ZES_EVENT_TYPE_FLAG_ENERGY_THRESHOLD_CROSSED);
       }
     } else {
-<<<<<<< HEAD
-      LOG_INFO << "No events handles found for this device!";
-    }
-  }
-  if (!is_events_supported) {
-    FAIL() << "No events handles found on any of the devices!";
-=======
       LOG_INFO << "No power handles found for this device!";
     }
   }
   if (!is_handles_available) {
     FAIL() << "No power handles found on any of the devices!";
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
   }
 
   // If we registered to receive events on any devices, start listening now
@@ -734,13 +696,8 @@ LZT_TEST_F(
     uint32_t count = 0;
     count = lzt::get_ras_handles_count(device);
     if (count > 0) {
-<<<<<<< HEAD
-      is_events_supported = true;
-      LOG_INFO << "Events handles are available on this device!";
-=======
       is_handles_available = true;
-      LOG_INFO << "RAS handles are available on this device!";
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
+      LOG_INFO << "Ras handles are available on this device!";
 
       auto ras_handles = lzt::get_ras_handles(device, count);
       for (auto ras_handle : ras_handles) {
@@ -766,19 +723,11 @@ LZT_TEST_F(
         lzt::register_event(device, setEvent);
       }
     } else {
-<<<<<<< HEAD
-      LOG_INFO << "No events handles are available on this device!";
-    }
-  }
-  if (!is_events_supported) {
-    FAIL() << "No Events handles are available on any device!";
-=======
-      LOG_INFO << "No ras handles found for this device!";
+      LOG_INFO << "No ras handles found on this device!";
     }
   }
   if (!is_handles_available) {
-    FAIL() << "No ras handles are available on any of the devices!";
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
+    FAIL() << "No ras handles found on any of the devices!";
   }
 
   // If we registered to receive events on any devices, start listening now
@@ -808,13 +757,8 @@ LZT_TEST_F(
     uint32_t count = 0;
     count = lzt::get_ras_handles_count(device);
     if (count > 0) {
-<<<<<<< HEAD
-      is_events_supported = true;
-      LOG_INFO << "Events handles are available on this device!";
-=======
       is_handles_available = true;
-      LOG_INFO << "RAS handles are available on this device!";
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
+      LOG_INFO << "Ras handles are available on this device!";
       auto ras_handles = lzt::get_ras_handles(device, count);
       for (auto ras_handle : ras_handles) {
         auto props = lzt::get_ras_properties(ras_handle);
@@ -840,19 +784,11 @@ LZT_TEST_F(
         lzt::register_event(device, setEvent);
       }
     } else {
-<<<<<<< HEAD
-      LOG_INFO << "No events handles are available on this device!";
-    }
-  }
-  if (!is_events_supported) {
-    FAIL() << "No events handles are available on any device!";
-=======
-      LOG_INFO << "No ras handles found for this device!";
+      LOG_INFO << "No ras handles available on this device!";
     }
   }
   if (!is_handles_available) {
-    FAIL() << "No ras handles are found on any of the devices!";
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
+    FAIL() << "No ras handles found on any of the devices!";
   }
 
   // If we registered to receive events on any devices, start listening now

--- a/conformance_tests/sysman/test_sysman_events/src/test_sysman_events.cpp
+++ b/conformance_tests/sysman/test_sysman_events/src/test_sysman_events.cpp
@@ -24,7 +24,11 @@ namespace {
 class EventsZesTest : public lzt::ZesSysmanCtsClass {
 public:
   ze_driver_handle_t hDriver;
+<<<<<<< HEAD
   bool is_events_supported = false;
+=======
+  bool is_handles_available = false;
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
   uint32_t timeout;
   uint64_t timeoutEx;
   EventsZesTest() {
@@ -39,7 +43,11 @@ public:
 class EventsTest : public lzt::SysmanCtsClass {
 public:
   ze_driver_handle_t hDriver;
+<<<<<<< HEAD
   bool is_events_supported = false;
+=======
+  bool is_handles_available = false;
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
   uint32_t timeout;
   uint64_t timeoutEx;
   EventsTest() {
@@ -63,36 +71,44 @@ LZT_TEST_F(
     GivenValidEventHandleWhenListeningTemperatureEventsForCriticalOrThresholdTempThenEventsAreTriggered) {
   for (auto device : devices) {
     uint32_t num_temp_sensors = 0;
-    auto temp_handles = lzt::get_temp_handles(device, num_temp_sensors);
-    if (num_temp_sensors == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    num_temp_sensors = lzt::get_temp_handle_count(device);
+    if (num_temp_sensors > 0) {
+      is_handles_available = true;
+      LOG_INFO << "Temperature handles are available on this device";
+      auto temp_handles = lzt::get_temp_handles(device, num_temp_sensors);
+      for (auto temp_handle : temp_handles) {
+        auto temp_properties = lzt::get_temp_properties(temp_handle);
+        auto temp_config = lzt::get_temp_config(temp_handle);
+        auto tempLimit = lzt::get_temp_state(temp_handle);
+        if (temp_properties.isCriticalTempSupported) {
+          temp_config.enableCritical = true;
+        }
+        if (temp_properties.isThreshold1Supported) {
+          temp_config.threshold1.enableHighToLow = false;
+          temp_config.threshold1.enableLowToHigh = true;
+          // Setting threshold couple of degree above the current temperature
+          temp_config.threshold1.threshold = tempLimit + 2;
+          temp_config.threshold2.enableHighToLow = false;
+          temp_config.threshold2.enableLowToHigh = false;
+        }
+        if ((temp_properties.isCriticalTempSupported == false) ||
+            (temp_properties.isThreshold1Supported == false)) {
+          // continue, as HW is not supporting the events
+          continue;
+        }
+        ASSERT_ZE_RESULT_SUCCESS(
+            lzt::set_temp_config(temp_handle, temp_config));
+        zes_event_type_flags_t setEvents = ZES_EVENT_TYPE_FLAG_TEMP_CRITICAL |
+                                           ZES_EVENT_TYPE_FLAG_TEMP_THRESHOLD1 |
+                                           ZES_EVENT_TYPE_FLAG_TEMP_THRESHOLD2;
+      }
+    } else {
+      LOG_INFO << "No temperature handles found for this devcie! ";
     }
-    for (auto temp_handle : temp_handles) {
-      auto temp_properties = lzt::get_temp_properties(temp_handle);
-      auto temp_config = lzt::get_temp_config(temp_handle);
-      auto tempLimit = lzt::get_temp_state(temp_handle);
-      if (temp_properties.isCriticalTempSupported) {
-        temp_config.enableCritical = true;
-      }
-      if (temp_properties.isThreshold1Supported) {
-        temp_config.threshold1.enableHighToLow = false;
-        temp_config.threshold1.enableLowToHigh = true;
-        // Setting threshold couple of degree above the current temperature
-        temp_config.threshold1.threshold = tempLimit + 2;
-        temp_config.threshold2.enableHighToLow = false;
-        temp_config.threshold2.enableLowToHigh = false;
-      }
-      if ((temp_properties.isCriticalTempSupported == false) ||
-          (temp_properties.isThreshold1Supported == false)) {
-        // continue, as HW is not supporting the events
-        continue;
-      }
-      ASSERT_ZE_RESULT_SUCCESS(lzt::set_temp_config(temp_handle, temp_config));
-      zes_event_type_flags_t setEvents = ZES_EVENT_TYPE_FLAG_TEMP_CRITICAL |
-                                         ZES_EVENT_TYPE_FLAG_TEMP_THRESHOLD1 |
-                                         ZES_EVENT_TYPE_FLAG_TEMP_THRESHOLD2;
-    }
+  }
+  if (!is_handles_available) {
+    FAIL() << "No temperature handles found on any of the devices! "
+           << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
   // If we registered to receive events on any devices, start listening now
   uint32_t num_device_events = 0;
@@ -443,8 +459,13 @@ LZT_TEST_F(
   for (auto device : devices) {
     uint32_t count = lzt::get_power_handle_count(device);
     if (count > 0) {
+<<<<<<< HEAD
       is_events_supported = true;
       LOG_INFO << "Events handles are available on this device!";
+=======
+      is_handles_available = true;
+      LOG_INFO << "Power handles are available on this device!";
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
       auto power_handles = lzt::get_power_handles(device, count);
       ASSERT_EQ(power_handles.size(), count);
       for (auto power_handle : power_handles) {
@@ -467,12 +488,21 @@ LZT_TEST_F(
                             ZES_EVENT_TYPE_FLAG_ENERGY_THRESHOLD_CROSSED);
       }
     } else {
+<<<<<<< HEAD
       LOG_INFO << "No events handles found for this device!";
     }
   }
 
   if (!is_events_supported) {
     FAIL() << "No events handles found on any of the devices!";
+=======
+      LOG_INFO << "No power handles found for this device!";
+    }
+  }
+
+  if (!is_handles_available) {
+    FAIL() << "No power handles found on any of the devices!";
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
   }
 
   // If we registered to receive events on any devices, start listening now
@@ -498,8 +528,13 @@ LZT_TEST_F(
   for (auto device : devices) {
     uint32_t count = lzt::get_power_handle_count(device);
     if (count > 0) {
+<<<<<<< HEAD
       is_events_supported = true;
       LOG_INFO << "Events handles are available on this device!";
+=======
+      is_handles_available = true;
+      LOG_INFO << "Power handles are available on this device!";
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
       auto power_handles = lzt::get_power_handles(device, count);
       ASSERT_EQ(power_handles.size(), count);
       for (auto power_handle : power_handles) {
@@ -522,11 +557,19 @@ LZT_TEST_F(
                             ZES_EVENT_TYPE_FLAG_ENERGY_THRESHOLD_CROSSED);
       }
     } else {
+<<<<<<< HEAD
       LOG_INFO << "No events handles found for this device!";
     }
   }
   if (!is_events_supported) {
     FAIL() << "No events handles found on any of the devices!";
+=======
+      LOG_INFO << "No power handles found for this device!";
+    }
+  }
+  if (!is_handles_available) {
+    FAIL() << "No power handles found on any of the devices!";
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
   }
 
   // If we registered to receive events on any devices, start listening now
@@ -691,8 +734,13 @@ LZT_TEST_F(
     uint32_t count = 0;
     count = lzt::get_ras_handles_count(device);
     if (count > 0) {
+<<<<<<< HEAD
       is_events_supported = true;
       LOG_INFO << "Events handles are available on this device!";
+=======
+      is_handles_available = true;
+      LOG_INFO << "RAS handles are available on this device!";
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
 
       auto ras_handles = lzt::get_ras_handles(device, count);
       for (auto ras_handle : ras_handles) {
@@ -718,11 +766,19 @@ LZT_TEST_F(
         lzt::register_event(device, setEvent);
       }
     } else {
+<<<<<<< HEAD
       LOG_INFO << "No events handles are available on this device!";
     }
   }
   if (!is_events_supported) {
     FAIL() << "No Events handles are available on any device!";
+=======
+      LOG_INFO << "No ras handles found for this device!";
+    }
+  }
+  if (!is_handles_available) {
+    FAIL() << "No ras handles are available on any of the devices!";
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
   }
 
   // If we registered to receive events on any devices, start listening now
@@ -752,8 +808,13 @@ LZT_TEST_F(
     uint32_t count = 0;
     count = lzt::get_ras_handles_count(device);
     if (count > 0) {
+<<<<<<< HEAD
       is_events_supported = true;
       LOG_INFO << "Events handles are available on this device!";
+=======
+      is_handles_available = true;
+      LOG_INFO << "RAS handles are available on this device!";
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
       auto ras_handles = lzt::get_ras_handles(device, count);
       for (auto ras_handle : ras_handles) {
         auto props = lzt::get_ras_properties(ras_handle);
@@ -779,11 +840,19 @@ LZT_TEST_F(
         lzt::register_event(device, setEvent);
       }
     } else {
+<<<<<<< HEAD
       LOG_INFO << "No events handles are available on this device!";
     }
   }
   if (!is_events_supported) {
     FAIL() << "No events handles are available on any device!";
+=======
+      LOG_INFO << "No ras handles found for this device!";
+    }
+  }
+  if (!is_handles_available) {
+    FAIL() << "No ras handles are found on any of the devices!";
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
   }
 
   // If we registered to receive events on any devices, start listening now

--- a/conformance_tests/sysman/test_sysman_firmware/src/test_sysman_firmware.cpp
+++ b/conformance_tests/sysman/test_sysman_firmware/src/test_sysman_firmware.cpp
@@ -26,10 +26,16 @@ namespace {
 uint32_t get_prop_length(char *prop) { return std::strlen(prop); }
 
 #ifdef USE_ZESINIT
-class FirmwareZesTest : public lzt::ZesSysmanCtsClass {};
+class FirmwareZesTest : public lzt::ZesSysmanCtsClass {
+public:
+  bool is_firmware_supported = false;
+};
 #define FIRMWARE_TEST FirmwareZesTest
 #else // USE_ZESINIT
-class FirmwareTest : public lzt::SysmanCtsClass {};
+class FirmwareTest : public lzt::SysmanCtsClass {
+public:
+  bool is_firmware_supported = false;
+};
 #define FIRMWARE_TEST FirmwareTest
 #endif // USE_ZESINIT
 
@@ -39,10 +45,15 @@ LZT_TEST_F(
   for (auto device : devices) {
     uint32_t count = 0;
     count = lzt::get_firmware_handle_count(device);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    if (count > 0) {
+      is_firmware_supported = true;
+      LOG_INFO << "Firmware handles are available on this device! ";
+    } else {
+      LOG_INFO << "No firmware handles found for this device! ";
     }
+  }
+  if (!is_firmware_supported) {
+    FAIL() << "No firmware handles found on any of the devices! ";
   }
 }
 LZT_TEST_F(
@@ -50,16 +61,21 @@ LZT_TEST_F(
     GivenComponentCountZeroWhenRetrievingFirmwareHandlesThenNotNullFirmwareHandlesAreReturned) {
   for (auto device : devices) {
     uint32_t count = 0;
-    auto firmware_handles = lzt::get_firmware_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    count = lzt::get_firmware_handle_count(device);
+    if (count > 0) {
+      is_firmware_supported = true;
+      LOG_INFO << "Firmware handles are available on this device! ";
+      auto firmware_handles = lzt::get_firmware_handles(device, count);
+      ASSERT_EQ(firmware_handles.size(), count);
+      for (auto firmware_handle : firmware_handles) {
+        ASSERT_NE(nullptr, firmware_handle);
+      }
+    } else {
+      LOG_INFO << "No firmware handles found for this device! ";
     }
-
-    ASSERT_EQ(firmware_handles.size(), count);
-    for (auto firmware_handle : firmware_handles) {
-      ASSERT_NE(nullptr, firmware_handle);
-    }
+  }
+  if (!is_firmware_supported) {
+    FAIL() << "No firmware handles found on any of the devices! ";
   }
 }
 
@@ -68,15 +84,20 @@ LZT_TEST_F(
     GivenInvalidComponentCountWhenRetrievingSysmanFirmwareHandlesThenActualComponentCountIsUpdated) {
   for (auto device : devices) {
     uint32_t actual_count = 0;
-    auto firmware_handles = lzt::get_firmware_handles(device, actual_count);
-    if (actual_count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    actual_count = lzt::get_firmware_handle_count(device);
+    if (actual_count > 0) {
+      is_firmware_supported = true;
+      LOG_INFO << "Firmware handles are available on this device! ";
+      auto firmware_handles = lzt::get_firmware_handles(device, actual_count);
+      uint32_t test_count = actual_count + 1;
+      firmware_handles = lzt::get_firmware_handles(device, test_count);
+      EXPECT_EQ(test_count, actual_count);
+    } else {
+      LOG_INFO << "No firmware handles found for this device! ";
     }
-
-    uint32_t test_count = actual_count + 1;
-    firmware_handles = lzt::get_firmware_handles(device, test_count);
-    EXPECT_EQ(test_count, actual_count);
+  }
+  if (!is_firmware_supported) {
+    FAIL() << "No firmware handles found on any of the devices! ";
   }
 }
 LZT_TEST_F(
@@ -85,22 +106,28 @@ LZT_TEST_F(
   for (auto device : devices) {
     auto deviceProperties = lzt::get_sysman_device_properties(device);
     uint32_t count = 0;
-    auto firmware_handles = lzt::get_firmware_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
-    }
-
-    for (auto firmware_handle : firmware_handles) {
-      ASSERT_NE(nullptr, firmware_handle);
-      auto properties = lzt::get_firmware_properties(firmware_handle);
-      if (properties.onSubdevice) {
-        EXPECT_LT(properties.subdeviceId, deviceProperties.numSubdevices);
+    count = lzt::get_firmware_handle_count(device);
+    if (count > 0) {
+      is_firmware_supported = true;
+      LOG_INFO << "Firmware handles are available on this device! ";
+      auto firmware_handles = lzt::get_firmware_handles(device, count);
+      for (auto firmware_handle : firmware_handles) {
+        ASSERT_NE(nullptr, firmware_handle);
+        auto properties = lzt::get_firmware_properties(firmware_handle);
+        if (properties.onSubdevice) {
+          EXPECT_LT(properties.subdeviceId, deviceProperties.numSubdevices);
+        }
+        EXPECT_LT(get_prop_length(properties.name), ZES_STRING_PROPERTY_SIZE);
+        EXPECT_GT(get_prop_length(properties.name), 0);
+        EXPECT_LT(get_prop_length(properties.version),
+                  ZES_STRING_PROPERTY_SIZE);
       }
-      EXPECT_LT(get_prop_length(properties.name), ZES_STRING_PROPERTY_SIZE);
-      EXPECT_GT(get_prop_length(properties.name), 0);
-      EXPECT_LT(get_prop_length(properties.version), ZES_STRING_PROPERTY_SIZE);
+    } else {
+      LOG_INFO << "No firmware handles found for this device! ";
     }
+  }
+  if (!is_firmware_supported) {
+    FAIL() << "No firmware handles found on any of the devices! ";
   }
 }
 
@@ -109,28 +136,35 @@ LZT_TEST_F(
     GivenValidFirmwareHandleWhenRetrievingFirmwarePropertiesThenExpectSamePropertiesReturnedTwice) {
   for (auto device : devices) {
     uint32_t count = 0;
-    auto firmware_handles = lzt::get_firmware_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
-    }
-
-    for (auto firmware_handle : firmware_handles) {
-      ASSERT_NE(nullptr, firmware_handle);
-      auto properties_initial = lzt::get_firmware_properties(firmware_handle);
-      auto properties_later = lzt::get_firmware_properties(firmware_handle);
-      EXPECT_EQ(properties_initial.onSubdevice, properties_later.onSubdevice);
-      if (properties_initial.onSubdevice && properties_later.onSubdevice) {
-        EXPECT_EQ(properties_initial.subdeviceId, properties_later.subdeviceId);
+    count = lzt::get_firmware_handle_count(device);
+    if (count > 0) {
+      is_firmware_supported = true;
+      LOG_INFO << "Firmware handles are available on this device! ";
+      auto firmware_handles = lzt::get_firmware_handles(device, count);
+      for (auto firmware_handle : firmware_handles) {
+        ASSERT_NE(nullptr, firmware_handle);
+        auto properties_initial = lzt::get_firmware_properties(firmware_handle);
+        auto properties_later = lzt::get_firmware_properties(firmware_handle);
+        EXPECT_EQ(properties_initial.onSubdevice, properties_later.onSubdevice);
+        if (properties_initial.onSubdevice && properties_later.onSubdevice) {
+          EXPECT_EQ(properties_initial.subdeviceId,
+                    properties_later.subdeviceId);
+        }
+        EXPECT_TRUE(
+            0 == std::strcmp(reinterpret_cast<char *>(properties_initial.name),
+                             reinterpret_cast<char *>(properties_later.name)));
+        EXPECT_TRUE(
+            0 ==
+            std::strcmp(reinterpret_cast<char *>(properties_initial.version),
+                        reinterpret_cast<char *>(properties_later.version)));
+        EXPECT_EQ(properties_initial.canControl, properties_later.canControl);
       }
-      EXPECT_TRUE(0 ==
-                  std::strcmp(reinterpret_cast<char *>(properties_initial.name),
-                              reinterpret_cast<char *>(properties_later.name)));
-      EXPECT_TRUE(
-          0 == std::strcmp(reinterpret_cast<char *>(properties_initial.version),
-                           reinterpret_cast<char *>(properties_later.version)));
-      EXPECT_EQ(properties_initial.canControl, properties_later.canControl);
+    } else {
+      LOG_INFO << "No firmware handles found for this device! ";
     }
+  }
+  if (!is_firmware_supported) {
+    FAIL() << "No firmware handles found on any of the devices! ";
   }
 }
 
@@ -146,31 +180,37 @@ LZT_TEST_F(
   std::string fwDir(fwDirEnv);
   for (auto device : devices) {
     uint32_t count = 0;
-    auto firmware_handles = lzt::get_firmware_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
-    }
-
-    for (auto firmware_handle : firmware_handles) {
-      ASSERT_NE(nullptr, firmware_handle);
-      auto propFw = lzt::get_firmware_properties(firmware_handle);
-      if (propFw.canControl == true) {
-        std::string fwName(reinterpret_cast<char *>(propFw.name));
-        std::string fwToLoad = fwDir + "/" + fwName + ".bin";
-        std::ifstream inFileStream(fwToLoad, std::ios::binary | std::ios::ate);
-        if (!inFileStream.is_open()) {
-          LOG_INFO << "Skipping test as firmware image not found";
-          GTEST_SKIP();
+    count = lzt::get_firmware_handle_count(device);
+    if (count > 0) {
+      is_firmware_supported = true;
+      LOG_INFO << "Firnware handles are available on this device! ";
+      auto firmware_handles = lzt::get_firmware_handles(device, count);
+      for (auto firmware_handle : firmware_handles) {
+        ASSERT_NE(nullptr, firmware_handle);
+        auto propFw = lzt::get_firmware_properties(firmware_handle);
+        if (propFw.canControl == true) {
+          std::string fwName(reinterpret_cast<char *>(propFw.name));
+          std::string fwToLoad = fwDir + "/" + fwName + ".bin";
+          std::ifstream inFileStream(fwToLoad,
+                                     std::ios::binary | std::ios::ate);
+          if (!inFileStream.is_open()) {
+            LOG_INFO << "Skipping test as firmware image not found";
+            GTEST_SKIP();
+          }
+          testFwImage.resize(inFileStream.tellg());
+          inFileStream.seekg(0, inFileStream.beg);
+          inFileStream.read(testFwImage.data(), testFwImage.size());
+          lzt::flash_firmware(firmware_handle,
+                              static_cast<void *>(testFwImage.data()),
+                              testFwImage.size());
         }
-        testFwImage.resize(inFileStream.tellg());
-        inFileStream.seekg(0, inFileStream.beg);
-        inFileStream.read(testFwImage.data(), testFwImage.size());
-        lzt::flash_firmware(firmware_handle,
-                            static_cast<void *>(testFwImage.data()),
-                            testFwImage.size());
       }
+    } else {
+      LOG_INFO << "No firmware handles found for this device! ";
     }
+  }
+  if (!is_firmware_supported) {
+    FAIL() << "No firmware handles found on any of the devices! ";
   }
 }
 
@@ -243,19 +283,22 @@ LZT_TEST_F(
   std::string fw_dir(fw_dir_env);
   for (auto device : devices) {
     uint32_t count = 0;
-    auto firmware_handles = lzt::get_firmware_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    if (count > 0) {
+      is_firmware_supported = true;
+      LOG_INFO << "Firnware handles are available on this device! ";
+      auto firmware_handles = lzt::get_firmware_handles(device, count);
+      for (auto firmware_handle : firmware_handles) {
+        std::thread firmware_flasher(flash_firmware, firmware_handle, fw_dir);
+        std::thread progress_tracker(track_firmware_flash, firmware_handle);
+        firmware_flasher.join();
+        progress_tracker.join();
+      }
+    } else {
+      LOG_INFO << "No firmware handles found for this device! ";
     }
-
-    for (auto firmware_handle : firmware_handles) {
-      std::thread firmware_flasher(flash_firmware, firmware_handle, fw_dir);
-      std::thread progress_tracker(track_firmware_flash, firmware_handle);
-
-      firmware_flasher.join();
-      progress_tracker.join();
-    }
+  }
+  if (!is_firmware_supported) {
+    FAIL() << "No firmware handles found on any of the devices! ";
   }
 }
 

--- a/conformance_tests/sysman/test_sysman_frequency/src/test_sysman_frequency.cpp
+++ b/conformance_tests/sysman/test_sysman_frequency/src/test_sysman_frequency.cpp
@@ -21,14 +21,16 @@ namespace {
 
 #ifdef USE_ZESINIT
 class FrequencyModuleZesTest : public lzt::ZesSysmanCtsClass {
-public:
-  bool freq_handles_available = false;
+	public:
+		bool is_freq_supported = false;
+		bool freq_handles_available = false;
 };
 #define FREQUENCY_TEST FrequencyModuleZesTest
 #else // USE_ZESINIT
 class FrequencyModuleTest : public lzt::SysmanCtsClass {
-public:
-  bool freq_handles_available = false;
+	public:
+	      	bool is_freq_supported = false;
+		bool freq_handles_available = false;
 };
 #define FREQUENCY_TEST FrequencyModuleTest
 #endif // USE_ZESINIT
@@ -46,15 +48,24 @@ LZT_TEST_F(
     GivenComponentCountZeroWhenRetrievingSysmanHandlesThenNotNullFrequencyHandlesAreReturned) {
   for (auto device : devices) {
     uint32_t count = 0;
-    auto pfreq_handles = lzt::get_freq_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    count = lzt::get_freq_handle_count(device);
+    if(count > 0)
+    {
+	    is_freq_supported = true;
+	    LOG_INFO << "Frequency handles are available on this device!";
+	    auto pfreq_handles = lzt::get_freq_handles(device, count);
+	    for (auto pfreq_handle : pfreq_handles) {
+	      	    EXPECT_NE(nullptr, pfreq_handle);
+	    }
     }
-
-    for (auto pfreq_handle : pfreq_handles) {
-      EXPECT_NE(nullptr, pfreq_handle);
+    else
+    {
+	    LOG_INFO << "No frequency handles found for this device! ";
     }
+  }
+  if(!is_freq_supported)
+  {
+	  FAIL() << "No frequency handles found on any of the devices: " << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
 
@@ -63,15 +74,24 @@ LZT_TEST_F(
     GivenComponentCountWhenRetrievingSysmanHandlesThenActualComponentCountIsUpdated) {
   for (auto device : devices) {
     uint32_t p_count = 0;
-    lzt::get_freq_handles(device, p_count);
-    if (p_count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    p_count = lzt::get_freq_handle_count(device);
+    if(p_count > 0)
+    {
+	    is_freq_supported = true;
+            LOG_INFO << "Frequency handles are available on this device!";
+	    lzt::get_freq_handles(device, p_count);
+	    uint32_t test_count = p_count + 1;
+	    lzt::get_freq_handles(device, test_count);
+	    EXPECT_EQ(test_count, p_count);
     }
-
-    uint32_t test_count = p_count + 1;
-    lzt::get_freq_handles(device, test_count);
-    EXPECT_EQ(test_count, p_count);
+    else
+    {
+	    LOG_INFO << "No frequency handles found for this device! ";
+    }
+  }
+  if(!is_freq_supported)
+  {
+          FAIL() << "No frequency handles found on any of the devices: " << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
 
@@ -80,21 +100,30 @@ LZT_TEST_F(
     GivenValidComponentCountWhenCallingApiTwiceThenSimilarFrequencyHandlesReturned) {
   for (auto device : devices) {
     uint32_t count = 0;
-    auto pfreq_handles_initial = lzt::get_freq_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    count = lzt::get_freq_handle_count(device);
+    if(count > 0)
+    {
+	    is_freq_supported = true;
+	    LOG_INFO << "Frequency handles are available on this device!";
+	    auto pfreq_handles_initial = lzt::get_freq_handles(device, count);
+	    for (auto pfreq_handle : pfreq_handles_initial) {
+	      	    EXPECT_NE(nullptr, pfreq_handle);
+	    }
+	    count = 0;
+	    auto pfreq_handles_later = lzt::get_freq_handles(device, count);
+	    for (auto pfreq_handle : pfreq_handles_later) {
+	      	    EXPECT_NE(nullptr, pfreq_handle);
+	    }
+	    EXPECT_EQ(pfreq_handles_initial, pfreq_handles_later);
     }
-
-    for (auto pfreq_handle : pfreq_handles_initial) {
-      EXPECT_NE(nullptr, pfreq_handle);
+    else
+    {
+	    LOG_INFO << "No frequency handles found for this device! ";
     }
-    count = 0;
-    auto pfreq_handles_later = lzt::get_freq_handles(device, count);
-    for (auto pfreq_handle : pfreq_handles_later) {
-      EXPECT_NE(nullptr, pfreq_handle);
-    }
-    EXPECT_EQ(pfreq_handles_initial, pfreq_handles_later);
+  }
+  if(!is_freq_supported)
+  {
+          FAIL() << "No frequency handles found on any of the devices! ";
   }
 }
 
@@ -103,17 +132,26 @@ LZT_TEST_F(
     GivenValidDeviceWhenRetrievingFreqStateThenValidFreqStatesAreReturned) {
   for (auto device : devices) {
     uint32_t count = 0;
-    auto pfreq_handles = lzt::get_freq_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    count = lzt::get_freq_handle_count(device);
+    if(count > 0)
+    {
+	    is_freq_supported = true;
+	    LOG_INFO << "Frequency handles are available on this device! ";
+	    auto pfreq_handles = lzt::get_freq_handles(device, count);
+	    for (auto pfreq_handle : pfreq_handles) {
+	      	    EXPECT_NE(nullptr, pfreq_handle);
+	      	    zes_freq_state_t pState = lzt::get_freq_state(pfreq_handle);
+	      	    lzt::validate_freq_state(pfreq_handle, pState);
+	    }
     }
-
-    for (auto pfreq_handle : pfreq_handles) {
-      EXPECT_NE(nullptr, pfreq_handle);
-      zes_freq_state_t pState = lzt::get_freq_state(pfreq_handle);
-      lzt::validate_freq_state(pfreq_handle, pState);
+    else
+    {
+	    LOG_INFO << "No frequency handles found for this device! ";
     }
+  }
+  if(!is_freq_supported)
+  {
+          FAIL() << "No frequency handles found on any of the devices: " << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
 
@@ -122,36 +160,45 @@ LZT_TEST_F(
     GivenValidFreqRangeWhenRetrievingFreqStateThenValidFreqStatesAreReturned) {
   for (auto device : devices) {
     uint32_t p_count = 0;
-    auto pfreq_handles = lzt::get_freq_handles(device, p_count);
-    if (p_count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    p_count = lzt::get_freq_handle_count(device);
+    if(p_count > 0)
+    {
+            is_freq_supported = true;
+            LOG_INFO << "Frequency handles are available on this device! ";
+	    auto pfreq_handles = lzt::get_freq_handles(device, p_count);
+	    for (auto pfreq_handle : pfreq_handles) {
+	      	    EXPECT_NE(nullptr, pfreq_handle);
+	      	    zes_freq_range_t limits = {};
+	      	    zes_freq_properties_t properties = {};
+	      	    properties = lzt::get_freq_properties(pfreq_handle);
+	      	    limits.min = properties.min;
+	      	    limits.max = properties.max;
+	      	    lzt::set_freq_range(pfreq_handle, limits);
+	      	    lzt::idle_check(pfreq_handle);
+	      	    zes_freq_state_t state = lzt::get_freq_state(pfreq_handle);
+	      	    lzt::validate_freq_state(pfreq_handle, state);
+	      	    if (state.actual > 0) {
+		    	    EXPECT_LE(state.actual, limits.max);
+		    	    EXPECT_GE(state.actual, limits.min);
+	      	    } else {
+		    	    LOG_INFO << "Actual frequency is unknown";
+	      	    }
+	      	    if (state.request > 0) {
+		    	    EXPECT_LE(state.request, limits.max);
+		    	    EXPECT_GE(state.request, limits.min);
+	      	    } else {
+		    	    LOG_INFO << "Requested frequency is unknown";
+	      	    }
+	    }
     }
-
-    for (auto pfreq_handle : pfreq_handles) {
-      EXPECT_NE(nullptr, pfreq_handle);
-      zes_freq_range_t limits = {};
-      zes_freq_properties_t properties = {};
-      properties = lzt::get_freq_properties(pfreq_handle);
-      limits.min = properties.min;
-      limits.max = properties.max;
-      lzt::set_freq_range(pfreq_handle, limits);
-      lzt::idle_check(pfreq_handle);
-      zes_freq_state_t state = lzt::get_freq_state(pfreq_handle);
-      lzt::validate_freq_state(pfreq_handle, state);
-      if (state.actual > 0) {
-        EXPECT_LE(state.actual, limits.max);
-        EXPECT_GE(state.actual, limits.min);
-      } else {
-        LOG_INFO << "Actual frequency is unknown";
-      }
-      if (state.request > 0) {
-        EXPECT_LE(state.request, limits.max);
-        EXPECT_GE(state.request, limits.min);
-      } else {
-        LOG_INFO << "Requested frequency is unknown";
-      }
+    else
+    {
+	    LOG_INFO << "No frequency handles found for this device! ";
     }
+  }
+  if(!is_freq_supported)
+  {
+          FAIL() << "No frequency handles found on any of the devices: " << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
 LZT_TEST_F(
@@ -159,20 +206,29 @@ LZT_TEST_F(
     GivenValidFrequencyHandleWhenRetrievingAvailableClocksThenSuccessAndSameValuesAreReturnedTwice) {
   for (auto device : devices) {
     uint32_t count = 0;
-    auto pfreq_handles = lzt::get_freq_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    count = lzt::get_freq_handle_count(device);
+    if(count > 0)
+    {
+	    is_freq_supported = true;
+	    LOG_INFO << "Frequency handles are availble on this device! ";
+	    auto pfreq_handles = lzt::get_freq_handles(device, count);
+	    for (auto pfreq_handle : pfreq_handles) {
+		    EXPECT_NE(nullptr, pfreq_handle);
+	      	    uint32_t icount = 0;
+	      	    uint32_t lcount = 0;
+	      	    auto pFrequencyInitial = lzt::get_available_clocks(pfreq_handle, icount);
+	      	    auto pFrequencyLater = lzt::get_available_clocks(pfreq_handle, lcount);
+	      	    EXPECT_EQ(pFrequencyInitial, pFrequencyLater);
+	    }
+    }  
+    else
+    {
+	    LOG_INFO << "No frequency handles found for this device! ";
     }
-
-    for (auto pfreq_handle : pfreq_handles) {
-      EXPECT_NE(nullptr, pfreq_handle);
-      uint32_t icount = 0;
-      uint32_t lcount = 0;
-      auto pFrequencyInitial = lzt::get_available_clocks(pfreq_handle, icount);
-      auto pFrequencyLater = lzt::get_available_clocks(pfreq_handle, lcount);
-      EXPECT_EQ(pFrequencyInitial, pFrequencyLater);
-    }
+  }
+  if(!is_freq_supported)
+  {
+          FAIL() << "No frequency handles found on any of the devices: " << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
 
@@ -208,6 +264,10 @@ LZT_TEST_F(
       }
     }
   }
+  if(!is_freq_supported)
+  {
+          FAIL() << "No frequency handles found on any of the devices: " << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+  }
 }
 LZT_TEST_F(
     FREQUENCY_TEST,
@@ -228,6 +288,10 @@ LZT_TEST_F(
       lzt::get_available_clocks(pfreq_handle, tCount);
       EXPECT_EQ(p_count, tCount);
     }
+  }
+  if(!is_freq_supported)
+  {
+          FAIL() << "No frequency handles found on any of the devices: " << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
 
@@ -258,6 +322,10 @@ LZT_TEST_F(
       }
     }
   }
+  if(!is_freq_supported)
+  {
+          FAIL() << "No frequency handles found on any of the devices: " << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+  }
 }
 
 LZT_TEST_F(
@@ -282,6 +350,10 @@ LZT_TEST_F(
         EXPECT_GT(properties.min, 0);
       }
     }
+  }
+  if(!is_freq_supported)
+  {
+          FAIL() << "No frequency handles found on any of the devices: " << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
 
@@ -317,6 +389,10 @@ LZT_TEST_F(
       EXPECT_EQ(properties[0].min, properties[i].min);
     }
   }
+  if(!is_freq_supported)
+  {
+          FAIL() << "No frequency handles found on any of the devices: " << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+  }
 }
 
 LZT_TEST_F(
@@ -336,6 +412,10 @@ LZT_TEST_F(
       for (uint32_t i = 0; i < 3; i++)
         freqRange = lzt::get_freq_range(pfreq_handle);
     }
+  }
+  if(!is_freq_supported)
+  {
+          FAIL() << "No frequency handles found on any of the devices: " << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
 
@@ -362,6 +442,10 @@ LZT_TEST_F(
       }
     }
   }
+  if(!is_freq_supported)
+  {
+          FAIL() << "No frequency handles found on any of the devices: " << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+  }
 }
 
 LZT_TEST_F(
@@ -378,6 +462,10 @@ LZT_TEST_F(
     zes_freq_range_t freqRange = {};
     for (auto pfreq_handle : pfreq_handles)
       freqRange = lzt::get_and_validate_freq_range(pfreq_handle);
+  }
+  if(!is_freq_supported)
+  {
+          FAIL() << "No frequency handles found on any of the devices: " << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
 
@@ -418,6 +506,10 @@ LZT_TEST_F(
         }
       }
     }
+  }
+  if(!is_freq_supported)
+  {
+          FAIL() << "No frequency handles found on any of the devices: " << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
 
@@ -482,6 +574,10 @@ LZT_TEST_F(
                     << get_freq_domain(freq_property.type);
       }
     }
+  }
+  if(!is_freq_supported)
+  {
+          FAIL() << "No frequency handles found on any of the devices: " << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
 
@@ -605,6 +701,10 @@ LZT_TEST_F(FREQUENCY_TEST, GivenValidFrequencyHandleThenCheckForThrottling) {
         }
       }
     }
+  }
+  if(!is_freq_supported)
+  {
+          FAIL() << "No frequency handles found on any of the devices: " << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
 
@@ -746,6 +846,10 @@ LZT_TEST_F(
       }
     }
   }
+  if(!is_freq_supported)
+  {
+          FAIL() << "No frequency handles found on any of the devices: " << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+  }
 }
 
 #ifdef __linux__
@@ -786,6 +890,10 @@ LZT_TEST_F(
     } else {
       LOG_WARNING << "No handles found on this device!";
     }
+  }
+  if(!is_freq_supported)
+  {
+          FAIL() << "No frequency handles found on any of the devices: " << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 
   if (!freq_handles_available) {

--- a/conformance_tests/sysman/test_sysman_led/src/test_sysman_led.cpp
+++ b/conformance_tests/sysman/test_sysman_led/src/test_sysman_led.cpp
@@ -20,10 +20,16 @@ namespace lzt = level_zero_tests;
 namespace {
 
 #ifdef USE_ZESINIT
-class LedModuleZesTest : public lzt::ZesSysmanCtsClass {};
+class LedModuleZesTest : public lzt::ZesSysmanCtsClass {
+	public:
+		bool is_led_supported = false;
+};
 #define LED_TEST LedModuleZesTest
 #else // USE_ZESINIT
-class LedModuleTest : public lzt::SysmanCtsClass {};
+class LedModuleTest : public lzt::SysmanCtsClass {
+        public:
+                bool is_led_supported = false;
+};
 #define LED_TEST LedModuleTest
 #endif // USE_ZESINIT
 
@@ -40,16 +46,25 @@ LZT_TEST_F(
     GivenComponentCountZeroWhenRetrievingSysmanHandlesThenNotNullLedHandlesAreReturned) {
   for (auto device : devices) {
     uint32_t count = 0;
-    auto led_handles = lzt::get_led_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    count = lzt::get_led_handle_count(device);
+    if (count > 0)
+    {
+	    is_led_supported = true;
+	    LOG_INFO << "Led handles are available on this device!";
+	    auto led_handles = lzt::get_led_handles(device, count);
+	    ASSERT_EQ(led_handles.size(), count);
+	    for (auto led_handle : led_handles) {
+	      	    ASSERT_NE(nullptr, led_handle);
+	    }
     }
-
-    ASSERT_EQ(led_handles.size(), count);
-    for (auto led_handle : led_handles) {
-      ASSERT_NE(nullptr, led_handle);
+    else
+    {
+	    LOG_INFO << "No led handles found for this device!";
     }
+  }
+  if(!is_led_supported)
+  {
+	  FAIL() << "No led handles found on any of the devices: " << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
 
@@ -58,15 +73,24 @@ LZT_TEST_F(
     GivenInvalidComponentCountWhenRetrievingSysmanHandlesThenActualComponentCountIsUpdated) {
   for (auto device : devices) {
     uint32_t actual_count = 0;
-    lzt::get_led_handles(device, actual_count);
-    if (actual_count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    actual_count = lzt::get_led_handle_count(device);
+    if (actual_count > 0)
+    {
+	    is_led_supported = true;
+            LOG_INFO << "Led handles are available on this device!";
+	    lzt::get_led_handles(device, actual_count);
+	    uint32_t test_count = actual_count + 1;
+	    lzt::get_led_handles(device, test_count);
+	    EXPECT_EQ(test_count, actual_count);
     }
-
-    uint32_t test_count = actual_count + 1;
-    lzt::get_led_handles(device, test_count);
-    EXPECT_EQ(test_count, actual_count);
+    else
+    {
+	    LOG_INFO << "No led handles found for this device!";
+    }
+  }
+  if(!is_led_supported)
+  {
+          FAIL() << "No led handles found on any of the devices: " << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
 
@@ -76,10 +100,6 @@ LZT_TEST_F(
   for (auto device : devices) {
     uint32_t count = 0;
     auto led_handles_initial = lzt::get_led_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
-    }
 
     for (auto led_handle : led_handles_initial) {
       ASSERT_NE(nullptr, led_handle);
@@ -100,19 +120,28 @@ LZT_TEST_F(
   for (auto device : devices) {
     auto deviceProperties = lzt::get_sysman_device_properties(device);
     uint32_t count = 0;
-    auto led_handles = lzt::get_led_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    count = lzt::get_led_handle_count(device);
+    if(count > 0)
+    {
+	    is_led_supported = true;
+	    LOG_INFO << "Led handles are available on this device!";
+	    auto led_handles = lzt::get_led_handles(device, count);
+	    for (auto led_handle : led_handles) {
+	      	    ASSERT_NE(nullptr, led_handle);
+	      	    auto properties = lzt::get_led_properties(led_handle);
+	      	    if (properties.onSubdevice) {
+		    	    EXPECT_LT(properties.subdeviceId, deviceProperties.numSubdevices);
+	      	    }
+	    }
     }
-
-    for (auto led_handle : led_handles) {
-      ASSERT_NE(nullptr, led_handle);
-      auto properties = lzt::get_led_properties(led_handle);
-      if (properties.onSubdevice) {
-        EXPECT_LT(properties.subdeviceId, deviceProperties.numSubdevices);
-      }
+    else
+    {
+	    LOG_INFO << "No led handles found for this device! ";
     }
+  }
+  if(!is_led_supported)
+  {
+	  FAIL() << "No led handles found on any of the devices: " << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
 
@@ -121,105 +150,141 @@ LZT_TEST_F(
     GivenValidLedHandleWhenRetrievingLedPropertiesThenExpectSamePropertiesReturnedTwice) {
   for (auto device : devices) {
     uint32_t count = 0;
-    auto led_handles = lzt::get_led_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    count = lzt::get_led_handle_count(device);
+    if(count > 0)
+    {
+	    is_led_supported = true;
+            LOG_INFO << "Led handles are available on this device!";
+	    auto led_handles = lzt::get_led_handles(device, count);
+	    for (auto led_handle : led_handles) {
+	      	    ASSERT_NE(nullptr, led_handle);
+	      	    auto properties_initial = lzt::get_led_properties(led_handle);
+	      	    auto properties_later = lzt::get_led_properties(led_handle);
+	      	    EXPECT_EQ(properties_initial.canControl, properties_later.canControl);
+	      	    if (properties_initial.onSubdevice && properties_later.onSubdevice) {
+		    	    EXPECT_EQ(properties_initial.subdeviceId, properties_later.subdeviceId);
+	      	    }
+	      	    EXPECT_EQ(properties_initial.haveRGB, properties_later.haveRGB);
+	    }
     }
-
-    for (auto led_handle : led_handles) {
-      ASSERT_NE(nullptr, led_handle);
-      auto properties_initial = lzt::get_led_properties(led_handle);
-      auto properties_later = lzt::get_led_properties(led_handle);
-      EXPECT_EQ(properties_initial.canControl, properties_later.canControl);
-      if (properties_initial.onSubdevice && properties_later.onSubdevice) {
-        EXPECT_EQ(properties_initial.subdeviceId, properties_later.subdeviceId);
-      }
-      EXPECT_EQ(properties_initial.haveRGB, properties_later.haveRGB);
+    else
+    {
+	    LOG_INFO << "No led handles found for this device! ";
     }
+  }
+  if(!is_led_supported)
+  {
+          FAIL() << "No led handles found on any of the devices: " << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
 LZT_TEST_F(LED_TEST,
            GivenValidLedHandleWhenRetrievingLedStateThenValidStateIsReturned) {
   for (auto device : devices) {
     uint32_t count = 0;
-    auto led_handles = lzt::get_led_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    count = lzt::get_led_handle_count(device);
+    if(count > 0)
+    {
+            is_led_supported = true;
+            LOG_INFO << "Led handles are available on this device!";
+	    auto led_handles = lzt::get_led_handles(device, count);
+	    for (auto led_handle : led_handles) {
+	      	    ASSERT_NE(nullptr, led_handle);
+	      	    auto properties = lzt::get_led_properties(led_handle);
+	      	    auto state = lzt::get_led_state(led_handle);
+	      	    if (state.isOn == false) {
+		    	    ASSERT_DOUBLE_EQ(state.color.red, 0.0);
+		    	    ASSERT_DOUBLE_EQ(state.color.green, 0.0);
+		    	    ASSERT_DOUBLE_EQ(state.color.blue, 0.0);
+	      	    } else {
+		    	    if ((state.color.red == 0.0) && (state.color.green == 0.0) &&
+					    (state.color.blue == 0.0))
+			  	    FAIL();
+		    	    else
+			  	    SUCCEED();
+	      	    }
+	    }
     }
-
-    for (auto led_handle : led_handles) {
-      ASSERT_NE(nullptr, led_handle);
-      auto properties = lzt::get_led_properties(led_handle);
-      auto state = lzt::get_led_state(led_handle);
-      if (state.isOn == false) {
-        ASSERT_DOUBLE_EQ(state.color.red, 0.0);
-        ASSERT_DOUBLE_EQ(state.color.green, 0.0);
-        ASSERT_DOUBLE_EQ(state.color.blue, 0.0);
-      } else {
-        if ((state.color.red == 0.0) && (state.color.green == 0.0) &&
-            (state.color.blue == 0.0))
-          FAIL();
-        else
-          SUCCEED();
-      }
+    else
+    {
+	    LOG_INFO << "No led handles found for this device! ";
     }
+  }
+  if(!is_led_supported)
+  {
+          FAIL() << "No led handles found on any of the devices: " << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
 LZT_TEST_F(LED_TEST,
            GivenValidLedHandleWhenSettingLedColorTheSuccessIsReturned) {
   for (auto device : devices) {
     uint32_t count = 0;
-    auto led_handles = lzt::get_led_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    count = lzt::get_led_handle_count(device);
+    if(count > 0)
+    {
+            is_led_supported = true;
+            LOG_INFO << "Led handles are available on this device!";
+	    auto led_handles = lzt::get_led_handles(device, count);
+	    for (auto led_handle : led_handles) {
+	      	    ASSERT_NE(nullptr, led_handle);
+	      	    auto initial_state = lzt::get_led_state(led_handle);
+	      	    if (initial_state.isOn == false) {
+		    	    lzt::set_led_state(led_handle, true);
+	      	    }
+	      	    zes_led_color_t color = {};
+	      	    color.red = 1.0;
+	      	    color.blue = 1.0;
+	      	    color.green = 1.0;
+	      	    lzt::set_led_color(led_handle, color);
+	      	    zes_led_state_t get_state = lzt::get_led_state(led_handle);
+	      	    EXPECT_EQ(get_state.isOn, true);
+	      	    EXPECT_DOUBLE_EQ(get_state.color.red, 1.0);
+	      	    EXPECT_DOUBLE_EQ(get_state.color.blue, 1.0);
+	      	    EXPECT_DOUBLE_EQ(get_state.color.green, 1.0);
+	      	    color.red = initial_state.color.red;
+	      	    color.blue = initial_state.color.blue;
+	      	    color.green = initial_state.color.green;
+	      	    lzt::set_led_color(led_handle, color);
+	    }
     }
-
-    for (auto led_handle : led_handles) {
-      ASSERT_NE(nullptr, led_handle);
-      auto initial_state = lzt::get_led_state(led_handle);
-      if (initial_state.isOn == false) {
-        lzt::set_led_state(led_handle, true);
-      }
-      zes_led_color_t color = {};
-      color.red = 1.0;
-      color.blue = 1.0;
-      color.green = 1.0;
-      lzt::set_led_color(led_handle, color);
-      zes_led_state_t get_state = lzt::get_led_state(led_handle);
-      EXPECT_EQ(get_state.isOn, true);
-      EXPECT_DOUBLE_EQ(get_state.color.red, 1.0);
-      EXPECT_DOUBLE_EQ(get_state.color.blue, 1.0);
-      EXPECT_DOUBLE_EQ(get_state.color.green, 1.0);
-      color.red = initial_state.color.red;
-      color.blue = initial_state.color.blue;
-      color.green = initial_state.color.green;
-      lzt::set_led_color(led_handle, color);
+    else
+    {
+	    LOG_INFO << "No led handles found for this device! ";
     }
+  }
+  if(!is_led_supported)
+  {
+	  FAIL() << "No led handles found on aby of the devices: " << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
 LZT_TEST_F(LED_TEST,
            GivenValidLedHandleWhenSettingLedStateToOffThenSuccessIsReturned) {
   for (auto device : devices) {
     uint32_t count = 0;
-    auto led_handles = lzt::get_led_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    count = lzt::get_led_handle_count(device);
+    if(count > 0)
+    {
+	    is_led_supported = true;
+            LOG_INFO << "Led handles are available on this device!";
+	    auto led_handles = lzt::get_led_handles(device, count);
+	    for (auto led_handle : led_handles) {
+	      	    ASSERT_NE(nullptr, led_handle);
+	      	    lzt::set_led_state(led_handle, false);
+	      	    auto get_state = lzt::get_led_state(led_handle);
+	      	    EXPECT_EQ(get_state.isOn, false);
+	      	    EXPECT_DOUBLE_EQ(get_state.color.red, 0.0);
+	      	    EXPECT_DOUBLE_EQ(get_state.color.blue, 0.0);
+	      	    EXPECT_DOUBLE_EQ(get_state.color.green, 0.0);
+	      	    lzt::set_led_state(led_handle, true);
+	    }
     }
-
-    for (auto led_handle : led_handles) {
-      ASSERT_NE(nullptr, led_handle);
-      lzt::set_led_state(led_handle, false);
-      auto get_state = lzt::get_led_state(led_handle);
-      EXPECT_EQ(get_state.isOn, false);
-      EXPECT_DOUBLE_EQ(get_state.color.red, 0.0);
-      EXPECT_DOUBLE_EQ(get_state.color.blue, 0.0);
-      EXPECT_DOUBLE_EQ(get_state.color.green, 0.0);
-      lzt::set_led_state(led_handle, true);
+    else
+    {
+	    LOG_INFO << "No led handles found for this device! ";
     }
+  }
+  if(!is_led_supported)
+  {
+          FAIL() << "No led handles found on aby of the devices: " << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
 

--- a/conformance_tests/sysman/test_sysman_led/src/test_sysman_led.cpp
+++ b/conformance_tests/sysman/test_sysman_led/src/test_sysman_led.cpp
@@ -21,14 +21,14 @@ namespace {
 
 #ifdef USE_ZESINIT
 class LedModuleZesTest : public lzt::ZesSysmanCtsClass {
-	public:
-		bool is_led_supported = false;
+public:
+  bool is_led_supported = false;
 };
 #define LED_TEST LedModuleZesTest
 #else // USE_ZESINIT
 class LedModuleTest : public lzt::SysmanCtsClass {
-        public:
-                bool is_led_supported = false;
+public:
+  bool is_led_supported = false;
 };
 #define LED_TEST LedModuleTest
 #endif // USE_ZESINIT
@@ -47,24 +47,20 @@ LZT_TEST_F(
   for (auto device : devices) {
     uint32_t count = 0;
     count = lzt::get_led_handle_count(device);
-    if (count > 0)
-    {
-	    is_led_supported = true;
-	    LOG_INFO << "Led handles are available on this device!";
-	    auto led_handles = lzt::get_led_handles(device, count);
-	    ASSERT_EQ(led_handles.size(), count);
-	    for (auto led_handle : led_handles) {
-	      	    ASSERT_NE(nullptr, led_handle);
-	    }
-    }
-    else
-    {
-	    LOG_INFO << "No led handles found for this device!";
+    if (count > 0) {
+      is_led_supported = true;
+      LOG_INFO << "Led handles are available on this device!";
+      auto led_handles = lzt::get_led_handles(device, count);
+      ASSERT_EQ(led_handles.size(), count);
+      for (auto led_handle : led_handles) {
+        ASSERT_NE(nullptr, led_handle);
+      }
+    } else {
+      LOG_INFO << "No led handles found for this device!";
     }
   }
-  if(!is_led_supported)
-  {
-	  FAIL() << "No led handles found on any of the devices: " << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+  if (!is_led_supported) {
+    FAIL() << "No led handles found on any of the devices! ";
   }
 }
 
@@ -74,23 +70,19 @@ LZT_TEST_F(
   for (auto device : devices) {
     uint32_t actual_count = 0;
     actual_count = lzt::get_led_handle_count(device);
-    if (actual_count > 0)
-    {
-	    is_led_supported = true;
-            LOG_INFO << "Led handles are available on this device!";
-	    lzt::get_led_handles(device, actual_count);
-	    uint32_t test_count = actual_count + 1;
-	    lzt::get_led_handles(device, test_count);
-	    EXPECT_EQ(test_count, actual_count);
-    }
-    else
-    {
-	    LOG_INFO << "No led handles found for this device!";
+    if (actual_count > 0) {
+      is_led_supported = true;
+      LOG_INFO << "Led handles are available on this device!";
+      lzt::get_led_handles(device, actual_count);
+      uint32_t test_count = actual_count + 1;
+      lzt::get_led_handles(device, test_count);
+      EXPECT_EQ(test_count, actual_count);
+    } else {
+      LOG_INFO << "No led handles found for this device!";
     }
   }
-  if(!is_led_supported)
-  {
-          FAIL() << "No led handles found on any of the devices: " << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+  if (!is_led_supported) {
+    FAIL() << "No led handles found on any of the devices! ";
   }
 }
 
@@ -99,18 +91,26 @@ LZT_TEST_F(
     GivenValidComponentCountWhenCallingApiTwiceThenSimilarLedHandlesReturned) {
   for (auto device : devices) {
     uint32_t count = 0;
-    auto led_handles_initial = lzt::get_led_handles(device, count);
-
-    for (auto led_handle : led_handles_initial) {
-      ASSERT_NE(nullptr, led_handle);
+    count = lzt::get_led_handle_count(device);
+    if (count > 0) {
+      is_led_supported = true;
+      LOG_INFO << "Led handles are available on this device!";
+      auto led_handles_initial = lzt::get_led_handles(device, count);
+      for (auto led_handle : led_handles_initial) {
+        ASSERT_NE(nullptr, led_handle);
+      }
+      count = 0;
+      auto led_handles_later = lzt::get_led_handles(device, count);
+      for (auto led_handle : led_handles_later) {
+        ASSERT_NE(nullptr, led_handle);
+      }
+      EXPECT_EQ(led_handles_initial, led_handles_later);
+    } else {
+      LOG_INFO << "No led handles found for this device! ";
     }
-
-    count = 0;
-    auto led_handles_later = lzt::get_led_handles(device, count);
-    for (auto led_handle : led_handles_later) {
-      ASSERT_NE(nullptr, led_handle);
-    }
-    EXPECT_EQ(led_handles_initial, led_handles_later);
+  }
+  if (!is_led_supported) {
+    FAIL() << "No led handles found on any of the devices! ";
   }
 }
 
@@ -121,27 +121,23 @@ LZT_TEST_F(
     auto deviceProperties = lzt::get_sysman_device_properties(device);
     uint32_t count = 0;
     count = lzt::get_led_handle_count(device);
-    if(count > 0)
-    {
-	    is_led_supported = true;
-	    LOG_INFO << "Led handles are available on this device!";
-	    auto led_handles = lzt::get_led_handles(device, count);
-	    for (auto led_handle : led_handles) {
-	      	    ASSERT_NE(nullptr, led_handle);
-	      	    auto properties = lzt::get_led_properties(led_handle);
-	      	    if (properties.onSubdevice) {
-		    	    EXPECT_LT(properties.subdeviceId, deviceProperties.numSubdevices);
-	      	    }
-	    }
-    }
-    else
-    {
-	    LOG_INFO << "No led handles found for this device! ";
+    if (count > 0) {
+      is_led_supported = true;
+      LOG_INFO << "Led handles are available on this device!";
+      auto led_handles = lzt::get_led_handles(device, count);
+      for (auto led_handle : led_handles) {
+        ASSERT_NE(nullptr, led_handle);
+        auto properties = lzt::get_led_properties(led_handle);
+        if (properties.onSubdevice) {
+          EXPECT_LT(properties.subdeviceId, deviceProperties.numSubdevices);
+        }
+      }
+    } else {
+      LOG_INFO << "No led handles found for this device! ";
     }
   }
-  if(!is_led_supported)
-  {
-	  FAIL() << "No led handles found on any of the devices: " << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+  if (!is_led_supported) {
+    FAIL() << "No led handles found on any of the devices! ";
   }
 }
 
@@ -151,30 +147,27 @@ LZT_TEST_F(
   for (auto device : devices) {
     uint32_t count = 0;
     count = lzt::get_led_handle_count(device);
-    if(count > 0)
-    {
-	    is_led_supported = true;
-            LOG_INFO << "Led handles are available on this device!";
-	    auto led_handles = lzt::get_led_handles(device, count);
-	    for (auto led_handle : led_handles) {
-	      	    ASSERT_NE(nullptr, led_handle);
-	      	    auto properties_initial = lzt::get_led_properties(led_handle);
-	      	    auto properties_later = lzt::get_led_properties(led_handle);
-	      	    EXPECT_EQ(properties_initial.canControl, properties_later.canControl);
-	      	    if (properties_initial.onSubdevice && properties_later.onSubdevice) {
-		    	    EXPECT_EQ(properties_initial.subdeviceId, properties_later.subdeviceId);
-	      	    }
-	      	    EXPECT_EQ(properties_initial.haveRGB, properties_later.haveRGB);
-	    }
-    }
-    else
-    {
-	    LOG_INFO << "No led handles found for this device! ";
+    if (count > 0) {
+      is_led_supported = true;
+      LOG_INFO << "Led handles are available on this device!";
+      auto led_handles = lzt::get_led_handles(device, count);
+      for (auto led_handle : led_handles) {
+        ASSERT_NE(nullptr, led_handle);
+        auto properties_initial = lzt::get_led_properties(led_handle);
+        auto properties_later = lzt::get_led_properties(led_handle);
+        EXPECT_EQ(properties_initial.canControl, properties_later.canControl);
+        if (properties_initial.onSubdevice && properties_later.onSubdevice) {
+          EXPECT_EQ(properties_initial.subdeviceId,
+                    properties_later.subdeviceId);
+        }
+        EXPECT_EQ(properties_initial.haveRGB, properties_later.haveRGB);
+      }
+    } else {
+      LOG_INFO << "No led handles found for this device! ";
     }
   }
-  if(!is_led_supported)
-  {
-          FAIL() << "No led handles found on any of the devices: " << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+  if (!is_led_supported) {
+    FAIL() << "No led handles found on any of the devices! ";
   }
 }
 LZT_TEST_F(LED_TEST,
@@ -182,36 +175,32 @@ LZT_TEST_F(LED_TEST,
   for (auto device : devices) {
     uint32_t count = 0;
     count = lzt::get_led_handle_count(device);
-    if(count > 0)
-    {
-            is_led_supported = true;
-            LOG_INFO << "Led handles are available on this device!";
-	    auto led_handles = lzt::get_led_handles(device, count);
-	    for (auto led_handle : led_handles) {
-	      	    ASSERT_NE(nullptr, led_handle);
-	      	    auto properties = lzt::get_led_properties(led_handle);
-	      	    auto state = lzt::get_led_state(led_handle);
-	      	    if (state.isOn == false) {
-		    	    ASSERT_DOUBLE_EQ(state.color.red, 0.0);
-		    	    ASSERT_DOUBLE_EQ(state.color.green, 0.0);
-		    	    ASSERT_DOUBLE_EQ(state.color.blue, 0.0);
-	      	    } else {
-		    	    if ((state.color.red == 0.0) && (state.color.green == 0.0) &&
-					    (state.color.blue == 0.0))
-			  	    FAIL();
-		    	    else
-			  	    SUCCEED();
-	      	    }
-	    }
-    }
-    else
-    {
-	    LOG_INFO << "No led handles found for this device! ";
+    if (count > 0) {
+      is_led_supported = true;
+      LOG_INFO << "Led handles are available on this device!";
+      auto led_handles = lzt::get_led_handles(device, count);
+      for (auto led_handle : led_handles) {
+        ASSERT_NE(nullptr, led_handle);
+        auto properties = lzt::get_led_properties(led_handle);
+        auto state = lzt::get_led_state(led_handle);
+        if (state.isOn == false) {
+          ASSERT_DOUBLE_EQ(state.color.red, 0.0);
+          ASSERT_DOUBLE_EQ(state.color.green, 0.0);
+          ASSERT_DOUBLE_EQ(state.color.blue, 0.0);
+        } else {
+          if ((state.color.red == 0.0) && (state.color.green == 0.0) &&
+              (state.color.blue == 0.0))
+            FAIL();
+          else
+            SUCCEED();
+        }
+      }
+    } else {
+      LOG_INFO << "No led handles found for this device! ";
     }
   }
-  if(!is_led_supported)
-  {
-          FAIL() << "No led handles found on any of the devices: " << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+  if (!is_led_supported) {
+    FAIL() << "No led handles found on any of the devices! ";
   }
 }
 LZT_TEST_F(LED_TEST,
@@ -219,41 +208,37 @@ LZT_TEST_F(LED_TEST,
   for (auto device : devices) {
     uint32_t count = 0;
     count = lzt::get_led_handle_count(device);
-    if(count > 0)
-    {
-            is_led_supported = true;
-            LOG_INFO << "Led handles are available on this device!";
-	    auto led_handles = lzt::get_led_handles(device, count);
-	    for (auto led_handle : led_handles) {
-	      	    ASSERT_NE(nullptr, led_handle);
-	      	    auto initial_state = lzt::get_led_state(led_handle);
-	      	    if (initial_state.isOn == false) {
-		    	    lzt::set_led_state(led_handle, true);
-	      	    }
-	      	    zes_led_color_t color = {};
-	      	    color.red = 1.0;
-	      	    color.blue = 1.0;
-	      	    color.green = 1.0;
-	      	    lzt::set_led_color(led_handle, color);
-	      	    zes_led_state_t get_state = lzt::get_led_state(led_handle);
-	      	    EXPECT_EQ(get_state.isOn, true);
-	      	    EXPECT_DOUBLE_EQ(get_state.color.red, 1.0);
-	      	    EXPECT_DOUBLE_EQ(get_state.color.blue, 1.0);
-	      	    EXPECT_DOUBLE_EQ(get_state.color.green, 1.0);
-	      	    color.red = initial_state.color.red;
-	      	    color.blue = initial_state.color.blue;
-	      	    color.green = initial_state.color.green;
-	      	    lzt::set_led_color(led_handle, color);
-	    }
-    }
-    else
-    {
-	    LOG_INFO << "No led handles found for this device! ";
+    if (count > 0) {
+      is_led_supported = true;
+      LOG_INFO << "Led handles are available on this device!";
+      auto led_handles = lzt::get_led_handles(device, count);
+      for (auto led_handle : led_handles) {
+        ASSERT_NE(nullptr, led_handle);
+        auto initial_state = lzt::get_led_state(led_handle);
+        if (initial_state.isOn == false) {
+          lzt::set_led_state(led_handle, true);
+        }
+        zes_led_color_t color = {};
+        color.red = 1.0;
+        color.blue = 1.0;
+        color.green = 1.0;
+        lzt::set_led_color(led_handle, color);
+        zes_led_state_t get_state = lzt::get_led_state(led_handle);
+        EXPECT_EQ(get_state.isOn, true);
+        EXPECT_DOUBLE_EQ(get_state.color.red, 1.0);
+        EXPECT_DOUBLE_EQ(get_state.color.blue, 1.0);
+        EXPECT_DOUBLE_EQ(get_state.color.green, 1.0);
+        color.red = initial_state.color.red;
+        color.blue = initial_state.color.blue;
+        color.green = initial_state.color.green;
+        lzt::set_led_color(led_handle, color);
+      }
+    } else {
+      LOG_INFO << "No led handles found for this device! ";
     }
   }
-  if(!is_led_supported)
-  {
-	  FAIL() << "No led handles found on aby of the devices: " << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+  if (!is_led_supported) {
+    FAIL() << "No led handles found on aby of the devices! ";
   }
 }
 LZT_TEST_F(LED_TEST,
@@ -261,30 +246,26 @@ LZT_TEST_F(LED_TEST,
   for (auto device : devices) {
     uint32_t count = 0;
     count = lzt::get_led_handle_count(device);
-    if(count > 0)
-    {
-	    is_led_supported = true;
-            LOG_INFO << "Led handles are available on this device!";
-	    auto led_handles = lzt::get_led_handles(device, count);
-	    for (auto led_handle : led_handles) {
-	      	    ASSERT_NE(nullptr, led_handle);
-	      	    lzt::set_led_state(led_handle, false);
-	      	    auto get_state = lzt::get_led_state(led_handle);
-	      	    EXPECT_EQ(get_state.isOn, false);
-	      	    EXPECT_DOUBLE_EQ(get_state.color.red, 0.0);
-	      	    EXPECT_DOUBLE_EQ(get_state.color.blue, 0.0);
-	      	    EXPECT_DOUBLE_EQ(get_state.color.green, 0.0);
-	      	    lzt::set_led_state(led_handle, true);
-	    }
-    }
-    else
-    {
-	    LOG_INFO << "No led handles found for this device! ";
+    if (count > 0) {
+      is_led_supported = true;
+      LOG_INFO << "Led handles are available on this device!";
+      auto led_handles = lzt::get_led_handles(device, count);
+      for (auto led_handle : led_handles) {
+        ASSERT_NE(nullptr, led_handle);
+        lzt::set_led_state(led_handle, false);
+        auto get_state = lzt::get_led_state(led_handle);
+        EXPECT_EQ(get_state.isOn, false);
+        EXPECT_DOUBLE_EQ(get_state.color.red, 0.0);
+        EXPECT_DOUBLE_EQ(get_state.color.blue, 0.0);
+        EXPECT_DOUBLE_EQ(get_state.color.green, 0.0);
+        lzt::set_led_state(led_handle, true);
+      }
+    } else {
+      LOG_INFO << "No led handles found for this device! ";
     }
   }
-  if(!is_led_supported)
-  {
-          FAIL() << "No led handles found on aby of the devices: " << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+  if (!is_led_supported) {
+    FAIL() << "No led handles found on aby of the devices! ";
   }
 }
 

--- a/conformance_tests/sysman/test_sysman_memory/src/test_sysman_memory.cpp
+++ b/conformance_tests/sysman/test_sysman_memory/src/test_sysman_memory.cpp
@@ -20,10 +20,16 @@ namespace lzt = level_zero_tests;
 namespace {
 
 #ifdef USE_ZESINIT
-class MemoryModuleZesTest : public lzt::ZesSysmanCtsClass {};
+class MemoryModuleZesTest : public lzt::ZesSysmanCtsClass {
+public:
+  bool is_mem_supported = false;
+};
 #define MEMORY_TEST MemoryModuleZesTest
 #else // USE_ZESINIT
-class MemoryModuleTest : public lzt::SysmanCtsClass {};
+class MemoryModuleTest : public lzt::SysmanCtsClass {
+public:
+  bool is_mem_supported = false;
+};
 #define MEMORY_TEST MemoryModuleTest
 #endif // USE_ZESINIT
 
@@ -32,11 +38,17 @@ LZT_TEST_F(
     GivenComponentCountZeroWhenRetrievingSysmanHandlesThenNonZeroCountIsReturned) {
   for (auto device : devices) {
     uint32_t count = 0;
-    auto mem_handles = lzt::get_mem_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    count = lzt::get_mem_handle_count(device);
+    if (count > 0) {
+      is_mem_supported = true;
+      LOG_INFO << "Memory handles are available on this device! ";
+      auto mem_handles = lzt::get_mem_handles(device, count);
+    } else {
+      LOG_INFO << "No memory handles found for this device! ";
     }
+  }
+  if (!is_mem_supported) {
+    FAIL() << "No memory handles found on any of the devices! ";
   }
 }
 
@@ -45,16 +57,21 @@ LZT_TEST_F(
     GivenComponentCountZeroWhenRetrievingSysmanHandlesThenNotNullMemoryHandlesAreReturned) {
   for (auto device : devices) {
     uint32_t count = 0;
-    auto mem_handles = lzt::get_mem_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    count = lzt::get_mem_handle_count(device);
+    if (count > 0) {
+      is_mem_supported = true;
+      LOG_INFO << "Memory handles are available on this device! ";
+      auto mem_handles = lzt::get_mem_handles(device, count);
+      ASSERT_EQ(mem_handles.size(), count);
+      for (auto mem_handle : mem_handles) {
+        EXPECT_NE(nullptr, mem_handle);
+      }
+    } else {
+      LOG_INFO << "No memory handles found for this device! ";
     }
-
-    ASSERT_EQ(mem_handles.size(), count);
-    for (auto mem_handle : mem_handles) {
-      EXPECT_NE(nullptr, mem_handle);
-    }
+  }
+  if (!is_mem_supported) {
+    FAIL() << "No memory handles found on any of the devices! ";
   }
 }
 
@@ -63,15 +80,20 @@ LZT_TEST_F(
     GivenInvalidComponentCountWhenRetrievingSysmanHandlesThenActualComponentCountIsUpdated) {
   for (auto device : devices) {
     uint32_t actual_count = 0;
-    lzt::get_mem_handles(device, actual_count);
-    if (actual_count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    actual_count = lzt::get_mem_handle_count(device);
+    if (actual_count > 0) {
+      is_mem_supported = true;
+      LOG_INFO << "Memory handles are available on this device! ";
+      lzt::get_mem_handles(device, actual_count);
+      uint32_t test_count = actual_count + 1;
+      lzt::get_mem_handles(device, test_count);
+      EXPECT_EQ(test_count, actual_count);
+    } else {
+      LOG_INFO << "No memory handles found for this device! ";
     }
-
-    uint32_t test_count = actual_count + 1;
-    lzt::get_mem_handles(device, test_count);
-    EXPECT_EQ(test_count, actual_count);
+  }
+  if (!is_mem_supported) {
+    FAIL() << "No memory handles found on any of the devices! ";
   }
 }
 
@@ -80,53 +102,61 @@ LZT_TEST_F(
     GivenValidComponentCountWhenCallingApiTwiceThenSimilarMemHandlesReturned) {
   for (auto device : devices) {
     uint32_t count = 0;
-    auto mem_handles_initial = lzt::get_mem_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    count = lzt::get_mem_handle_count(device);
+    if (count > 0) {
+      is_mem_supported = true;
+      LOG_INFO << "Memory handles are available on this device! ";
+      auto mem_handles_initial = lzt::get_mem_handles(device, count);
+      for (auto mem_handle : mem_handles_initial) {
+        EXPECT_NE(nullptr, mem_handle);
+      }
+      count = 0;
+      auto mem_handles_later = lzt::get_mem_handles(device, count);
+      for (auto mem_handle : mem_handles_later) {
+        EXPECT_NE(nullptr, mem_handle);
+      }
+      EXPECT_EQ(mem_handles_initial, mem_handles_later);
+    } else {
+      LOG_INFO << "No memory handles found for this device! ";
     }
-
-    for (auto mem_handle : mem_handles_initial) {
-      EXPECT_NE(nullptr, mem_handle);
-    }
-
-    count = 0;
-    auto mem_handles_later = lzt::get_mem_handles(device, count);
-    for (auto mem_handle : mem_handles_later) {
-      EXPECT_NE(nullptr, mem_handle);
-    }
-    EXPECT_EQ(mem_handles_initial, mem_handles_later);
+  }
+  if (!is_mem_supported) {
+    FAIL() << "No memory handles found on any of the devices! ";
   }
 }
-
 LZT_TEST_F(
     MEMORY_TEST,
     GivenValidMemHandleWhenRetrievingMemPropertiesThenValidPropertiesAreReturned) {
   for (auto device : devices) {
     auto deviceProperties = lzt::get_sysman_device_properties(device);
     uint32_t count = 0;
-    auto mem_handles = lzt::get_mem_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
-    }
-
-    for (auto mem_handle : mem_handles) {
-      ASSERT_NE(nullptr, mem_handle);
-      auto properties = lzt::get_mem_properties(mem_handle);
-      if (properties.onSubdevice) {
-        EXPECT_LT(properties.subdeviceId, deviceProperties.numSubdevices);
+    count = lzt::get_mem_handle_count(device);
+    if (count > 0) {
+      is_mem_supported = true;
+      LOG_INFO << "Memory handles are available on this device! ";
+      auto mem_handles = lzt::get_mem_handles(device, count);
+      for (auto mem_handle : mem_handles) {
+        ASSERT_NE(nullptr, mem_handle);
+        auto properties = lzt::get_mem_properties(mem_handle);
+        if (properties.onSubdevice) {
+          EXPECT_LT(properties.subdeviceId, deviceProperties.numSubdevices);
+        }
+        EXPECT_LT(properties.physicalSize, UINT64_MAX);
+        EXPECT_GE(properties.location, ZES_MEM_LOC_SYSTEM);
+        EXPECT_LE(properties.location, ZES_MEM_LOC_DEVICE);
+        EXPECT_LE(properties.busWidth, INT32_MAX);
+        EXPECT_GE(properties.busWidth, -1);
+        EXPECT_NE(properties.busWidth, 0);
+        EXPECT_LE(properties.numChannels, INT32_MAX);
+        EXPECT_GE(properties.numChannels, -1);
+        EXPECT_NE(properties.numChannels, 0);
       }
-      EXPECT_LT(properties.physicalSize, UINT64_MAX);
-      EXPECT_GE(properties.location, ZES_MEM_LOC_SYSTEM);
-      EXPECT_LE(properties.location, ZES_MEM_LOC_DEVICE);
-      EXPECT_LE(properties.busWidth, INT32_MAX);
-      EXPECT_GE(properties.busWidth, -1);
-      EXPECT_NE(properties.busWidth, 0);
-      EXPECT_LE(properties.numChannels, INT32_MAX);
-      EXPECT_GE(properties.numChannels, -1);
-      EXPECT_NE(properties.numChannels, 0);
+    } else {
+      LOG_INFO << "No memory handles found for this device! ";
     }
+  }
+  if (!is_mem_supported) {
+    FAIL() << "No memory handles found on any of the devices! ";
   }
 }
 
@@ -135,26 +165,33 @@ LZT_TEST_F(
     GivenValidMemHandleWhenRetrievingMemPropertiesThenExpectSamePropertiesReturnedTwice) {
   for (auto device : devices) {
     uint32_t count = 0;
-    auto mem_handles = lzt::get_mem_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
-    }
-
-    for (auto mem_handle : mem_handles) {
-      EXPECT_NE(nullptr, mem_handle);
-      auto properties_initial = lzt::get_mem_properties(mem_handle);
-      auto properties_later = lzt::get_mem_properties(mem_handle);
-      EXPECT_EQ(properties_initial.type, properties_later.type);
-      EXPECT_EQ(properties_initial.onSubdevice, properties_later.onSubdevice);
-      if (properties_initial.onSubdevice && properties_later.onSubdevice) {
-        EXPECT_EQ(properties_initial.subdeviceId, properties_later.subdeviceId);
+    count = lzt::get_mem_handle_count(device);
+    if (count > 0) {
+      is_mem_supported = true;
+      LOG_INFO << "Memory handles are available on this device! ";
+      auto mem_handles = lzt::get_mem_handles(device, count);
+      for (auto mem_handle : mem_handles) {
+        EXPECT_NE(nullptr, mem_handle);
+        auto properties_initial = lzt::get_mem_properties(mem_handle);
+        auto properties_later = lzt::get_mem_properties(mem_handle);
+        EXPECT_EQ(properties_initial.type, properties_later.type);
+        EXPECT_EQ(properties_initial.onSubdevice, properties_later.onSubdevice);
+        if (properties_initial.onSubdevice && properties_later.onSubdevice) {
+          EXPECT_EQ(properties_initial.subdeviceId,
+                    properties_later.subdeviceId);
+        }
+        EXPECT_EQ(properties_initial.physicalSize,
+                  properties_later.physicalSize);
+        EXPECT_EQ(properties_initial.location, properties_later.location);
+        EXPECT_EQ(properties_initial.busWidth, properties_later.busWidth);
+        EXPECT_EQ(properties_initial.numChannels, properties_later.numChannels);
       }
-      EXPECT_EQ(properties_initial.physicalSize, properties_later.physicalSize);
-      EXPECT_EQ(properties_initial.location, properties_later.location);
-      EXPECT_EQ(properties_initial.busWidth, properties_later.busWidth);
-      EXPECT_EQ(properties_initial.numChannels, properties_later.numChannels);
+    } else {
+      LOG_INFO << "No memory handles found for this device! ";
     }
+  }
+  if (!is_mem_supported) {
+    FAIL() << "No memory handles found on any of the devices! ";
   }
 }
 
@@ -163,20 +200,25 @@ LZT_TEST_F(
     GivenValidMemHandleWhenRetrievingMemBandWidthThenValidBandWidthCountersAreReturned) {
   for (auto device : devices) {
     uint32_t count = 0;
-    auto mem_handles = lzt::get_mem_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    count = lzt::get_mem_handle_count(device);
+    if (count > 0) {
+      is_mem_supported = true;
+      LOG_INFO << "Memory handles are available on this device! ";
+      auto mem_handles = lzt::get_mem_handles(device, count);
+      for (auto mem_handle : mem_handles) {
+        ASSERT_NE(nullptr, mem_handle);
+        auto bandwidth = lzt::get_mem_bandwidth(mem_handle);
+        EXPECT_LT(bandwidth.readCounter, UINT64_MAX);
+        EXPECT_LT(bandwidth.writeCounter, UINT64_MAX);
+        EXPECT_LT(bandwidth.maxBandwidth, UINT64_MAX);
+        EXPECT_LT(bandwidth.timestamp, UINT64_MAX);
+      }
+    } else {
+      LOG_INFO << "No memory handles found for this device! ";
     }
-
-    for (auto mem_handle : mem_handles) {
-      ASSERT_NE(nullptr, mem_handle);
-      auto bandwidth = lzt::get_mem_bandwidth(mem_handle);
-      EXPECT_LT(bandwidth.readCounter, UINT64_MAX);
-      EXPECT_LT(bandwidth.writeCounter, UINT64_MAX);
-      EXPECT_LT(bandwidth.maxBandwidth, UINT64_MAX);
-      EXPECT_LT(bandwidth.timestamp, UINT64_MAX);
-    }
+  }
+  if (!is_mem_supported) {
+    FAIL() << "No memory handles found on any of the devices! ";
   }
 }
 
@@ -184,23 +226,28 @@ LZT_TEST_F(MEMORY_TEST,
            GivenValidMemHandleWhenRetrievingMemStateThenValidStateIsReturned) {
   for (auto device : devices) {
     uint32_t count = 0;
-    auto mem_handles = lzt::get_mem_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
-    }
-
-    for (auto mem_handle : mem_handles) {
-      ASSERT_NE(nullptr, mem_handle);
-      auto state = lzt::get_mem_state(mem_handle);
-      EXPECT_GE(state.health, ZES_MEM_HEALTH_UNKNOWN);
-      EXPECT_LE(state.health, ZES_MEM_HEALTH_REPLACE);
-      auto properties = lzt::get_mem_properties(mem_handle);
-      if (properties.physicalSize != 0) {
-        EXPECT_LE(state.size, properties.physicalSize);
+    count = lzt::get_mem_handle_count(device);
+    if (count > 0) {
+      is_mem_supported = true;
+      LOG_INFO << "Memory handles are available on this device! ";
+      auto mem_handles = lzt::get_mem_handles(device, count);
+      for (auto mem_handle : mem_handles) {
+        ASSERT_NE(nullptr, mem_handle);
+        auto state = lzt::get_mem_state(mem_handle);
+        EXPECT_GE(state.health, ZES_MEM_HEALTH_UNKNOWN);
+        EXPECT_LE(state.health, ZES_MEM_HEALTH_REPLACE);
+        auto properties = lzt::get_mem_properties(mem_handle);
+        if (properties.physicalSize != 0) {
+          EXPECT_LE(state.size, properties.physicalSize);
+        }
+        EXPECT_LE(state.free, state.size);
       }
-      EXPECT_LE(state.free, state.size);
+    } else {
+      LOG_INFO << "No memory handles found for this device! ";
     }
+  }
+  if (!is_mem_supported) {
+    FAIL() << "No memory handles found on any of the devices! ";
   }
 }
 
@@ -413,37 +460,41 @@ LZT_TEST_F(MEMORY_TEST,
            GivenDeviceWhenRetrievingMemoryPropertiesThenLocationIsAsExpected) {
   for (auto device : devices) {
     uint32_t count = 0;
-    auto mem_handles = lzt::get_mem_handles(device, count);
-
-    if (count == 0) {
-      FAIL() << "No memory handles found on this device!";
-      continue;
-    }
-    ze_device_properties_t deviceProperties = {
-        ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES, nullptr};
+    count = lzt::get_mem_handle_count(device);
+    if (count > 0) {
+      is_mem_supported = true;
+      LOG_INFO << "Memory handles are available on this device! ";
+      auto mem_handles = lzt::get_mem_handles(device, count);
+      ze_device_properties_t deviceProperties = {
+          ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES, nullptr};
 #ifdef USE_ZESINIT
-    auto sysman_device_properties = lzt::get_sysman_device_properties(device);
-    ze_device_handle_t core_device =
-        lzt::get_core_device_by_uuid(sysman_device_properties.core.uuid.id);
-    EXPECT_NE(core_device, nullptr);
-    device = core_device;
+      auto sysman_device_properties = lzt::get_sysman_device_properties(device);
+      ze_device_handle_t core_device =
+          lzt::get_core_device_by_uuid(sysman_device_properties.core.uuid.id);
+      EXPECT_NE(core_device, nullptr);
+      device = core_device;
 #endif // USE_ZESINIT
-    EXPECT_ZE_RESULT_SUCCESS(zeDeviceGetProperties(device, &deviceProperties));
-    bool is_integrated =
-        (deviceProperties.flags & ZE_DEVICE_PROPERTY_FLAG_INTEGRATED);
-
-    for (auto mem_handle : mem_handles) {
-      ASSERT_NE(nullptr, mem_handle);
-
-      auto mem_properties = lzt::get_mem_properties(mem_handle);
-      if (is_integrated) {
-        EXPECT_EQ(mem_properties.location, ZES_MEM_LOC_SYSTEM)
-            << "Integrated device should have system memory location";
-      } else {
-        EXPECT_EQ(mem_properties.location, ZES_MEM_LOC_DEVICE)
-            << "Discrete device should have device memory location";
+      EXPECT_ZE_RESULT_SUCCESS(
+          zeDeviceGetProperties(device, &deviceProperties));
+      bool is_integrated =
+          (deviceProperties.flags & ZE_DEVICE_PROPERTY_FLAG_INTEGRATED);
+      for (auto mem_handle : mem_handles) {
+        ASSERT_NE(nullptr, mem_handle);
+        auto mem_properties = lzt::get_mem_properties(mem_handle);
+        if (is_integrated) {
+          EXPECT_EQ(mem_properties.location, ZES_MEM_LOC_SYSTEM)
+              << "Integrated device should have system memory location";
+        } else {
+          EXPECT_EQ(mem_properties.location, ZES_MEM_LOC_DEVICE)
+              << "Discrete device should have device memory location";
+        }
       }
+    } else {
+      LOG_INFO << "No memory handles found for this device! ";
     }
+  }
+  if (!is_mem_supported) {
+    FAIL() << "No memory handles found on any of the devices! ";
   }
 }
 

--- a/conformance_tests/sysman/test_sysman_psu/src/test_sysman_psu.cpp
+++ b/conformance_tests/sysman/test_sysman_psu/src/test_sysman_psu.cpp
@@ -19,10 +19,16 @@ namespace lzt = level_zero_tests;
 namespace {
 
 #ifdef USE_ZESINIT
-class PsuModuleZesTest : public lzt::ZesSysmanCtsClass {};
+class PsuModuleZesTest : public lzt::ZesSysmanCtsClass {
+public:
+  bool is_psu_supported = false;
+};
 #define PSU_TEST PsuModuleZesTest
 #else // USE_ZESINIT
-class PsuModuleTest : public lzt::SysmanCtsClass {};
+class PsuModuleTest : public lzt::SysmanCtsClass {
+public:
+  bool is_psu_supported = false;
+};
 #define PSU_TEST PsuModuleTest
 #endif // USE_ZESINIT
 
@@ -39,16 +45,22 @@ LZT_TEST_F(
     GivenComponentCountZeroWhenRetrievingSysmanHandlesThenNotNullPsuHandlesAreReturned) {
   for (auto device : devices) {
     uint32_t count = 0;
-    auto psu_handles = lzt::get_psu_handles(device, count);
-    ASSERT_EQ(psu_handles.size(), count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    count = lzt::get_psu_handles_count(device);
+    if (count > 0) {
+      is_psu_supported = true;
+      LOG_INFO << "PSU handles are available on this device!";
+      auto psu_handles = lzt::get_psu_handles(device, count);
+      ASSERT_EQ(psu_handles.size(), count);
+      for (auto psu_handle : psu_handles) {
+        ASSERT_NE(nullptr, psu_handle);
+      }
+    } else {
+      LOG_INFO << "PSU handles are not available on this device!";
     }
-
-    for (auto psu_handle : psu_handles) {
-      ASSERT_NE(nullptr, psu_handle);
-    }
+  }
+  if (!is_psu_supported) {
+    FAIL() << "No psu handles found: "
+           << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
 
@@ -57,15 +69,21 @@ LZT_TEST_F(
     GivenInvalidComponentCountWhenRetrievingSysmanHandlesThenActualComponentCountIsUpdated) {
   for (auto device : devices) {
     uint32_t actual_count = 0;
-    lzt::get_psu_handles(device, actual_count);
-    if (actual_count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    actual_count = lzt::get_psu_handles_count(device);
+    if (actual_count > 0) {
+      is_psu_supported = true;
+      LOG_INFO << "PSU handles are available on this device!";
+      lzt::get_psu_handles(device, actual_count);
+      uint32_t test_count = actual_count + 1;
+      lzt::get_psu_handles(device, test_count);
+      EXPECT_EQ(test_count, actual_count);
+    } else {
+      LOG_INFO << "PSU handles are not available on this device!";
     }
-
-    uint32_t test_count = actual_count + 1;
-    lzt::get_psu_handles(device, test_count);
-    EXPECT_EQ(test_count, actual_count);
+  }
+  if (!is_psu_supported) {
+    FAIL() << "No psu handles found: "
+           << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
 
@@ -74,23 +92,26 @@ LZT_TEST_F(
     GivenValidComponentCountWhenCallingApiTwiceThenSimilarMemHandlesReturned) {
   for (auto device : devices) {
     uint32_t count = 0;
-    auto psu_handles_initial = lzt::get_psu_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    count = lzt::get_psu_handles_count(device);
+    if (count > 0) {
+      is_psu_supported = true;
+      LOG_INFO << "PSU handles are available on this device!";
+      auto psu_handles_initial = lzt::get_psu_handles(device, count);
+      for (auto psu_handle : psu_handles_initial) {
+        ASSERT_NE(nullptr, psu_handle);
+      }
+      auto psu_handles_later = lzt::get_psu_handles(device, count);
+      for (auto psu_handle : psu_handles_later) {
+        ASSERT_NE(nullptr, psu_handle);
+      }
+      EXPECT_EQ(psu_handles_initial, psu_handles_later);
+    } else {
+      LOG_INFO << "PSU handles are not available on this device!";
     }
-
-    for (auto psu_handle : psu_handles_initial) {
-      ASSERT_NE(nullptr, psu_handle);
-    }
-
-    count = 0;
-    auto psu_handles_later = lzt::get_psu_handles(device, count);
-    for (auto psu_handle : psu_handles_later) {
-      ASSERT_NE(nullptr, psu_handle);
-    }
-
-    EXPECT_EQ(psu_handles_initial, psu_handles_later);
+  }
+  if (!is_psu_supported) {
+    FAIL() << "No psu devices found: "
+           << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
 LZT_TEST_F(
@@ -99,20 +120,26 @@ LZT_TEST_F(
   for (auto device : devices) {
     auto deviceProperties = lzt::get_sysman_device_properties(device);
     uint32_t count = 0;
-    auto psu_handles = lzt::get_psu_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
-    }
-
-    for (auto psu_handle : psu_handles) {
-      ASSERT_NE(nullptr, psu_handle);
-      auto properties = lzt::get_psu_properties(psu_handle);
-      EXPECT_LE(properties.ampLimit, UINT32_MAX);
-      if (properties.onSubdevice) {
-        EXPECT_LT(properties.subdeviceId, deviceProperties.numSubdevices);
+    count = lzt::get_psu_handles_count(device);
+    if (count > 0) {
+      is_psu_supported = true;
+      LOG_INFO << "PSU handles are available on this device!";
+      auto psu_handles = lzt::get_psu_handles(device, count);
+      for (auto psu_handle : psu_handles) {
+        ASSERT_NE(nullptr, psu_handle);
+        auto properties = lzt::get_psu_properties(psu_handle);
+        EXPECT_LE(properties.ampLimit, UINT32_MAX);
+        if (properties.onSubdevice) {
+          EXPECT_LT(properties.subdeviceId, deviceProperties.numSubdevices);
+        }
       }
+    } else {
+      LOG_INFO << "PSU handles are not available on this device!";
     }
+  }
+  if (!is_psu_supported) {
+    FAIL() << "No psu handles found: "
+           << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
 
@@ -121,44 +148,56 @@ LZT_TEST_F(
     GivenValidPsuHandleWhenRetrievingPsuPropertiesThenExpectSamePropertiesReturnedTwice) {
   for (auto device : devices) {
     uint32_t count = 0;
-    auto psu_handles = lzt::get_psu_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
-    }
-
-    for (auto psu_handle : psu_handles) {
-      ASSERT_NE(nullptr, psu_handle);
-      auto properties_initial = lzt::get_psu_properties(psu_handle);
-      auto properties_later = lzt::get_psu_properties(psu_handle);
-      EXPECT_EQ(properties_initial.haveFan, properties_later.haveFan);
-      EXPECT_EQ(properties_initial.onSubdevice, properties_later.onSubdevice);
-      EXPECT_EQ(properties_initial.subdeviceId, properties_later.subdeviceId);
-
-      EXPECT_EQ(properties_initial.ampLimit, properties_later.ampLimit);
+    count = lzt::get_psu_handles_count(device);
+    if (count > 0) {
+      is_psu_supported = true;
+      LOG_INFO << "PSU handles are available on this device!";
+      auto psu_handles = lzt::get_psu_handles(device, count);
+      for (auto psu_handle : psu_handles) {
+        ASSERT_NE(nullptr, psu_handle);
+        auto properties_initial = lzt::get_psu_properties(psu_handle);
+        auto properties_later = lzt::get_psu_properties(psu_handle);
+        EXPECT_EQ(properties_initial.haveFan, properties_later.haveFan);
+        EXPECT_EQ(properties_initial.onSubdevice, properties_later.onSubdevice);
+        EXPECT_EQ(properties_initial.subdeviceId, properties_later.subdeviceId);
+        EXPECT_EQ(properties_initial.ampLimit, properties_later.ampLimit);
+      }
+    } else {
+      LOG_INFO << "PSU handles are not available on this device!";
     }
   }
+  if (!is_psu_supported) {
+    FAIL() << "No psu handles found: "
+           << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+  }
 }
+
 LZT_TEST_F(PSU_TEST,
            GivenValidPsuHandleWhenRetrievingPsuStateThenValidStateIsReturned) {
   for (auto device : devices) {
     uint32_t count = 0;
-    auto psu_handles = lzt::get_psu_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    count = lzt::get_psu_handles_count(device);
+    if (count > 0) {
+      is_psu_supported = true;
+      LOG_INFO << "PSU handles are available on this device!";
+      auto psu_handles = lzt::get_psu_handles(device, count);
+      for (auto psu_handle : psu_handles) {
+        ASSERT_NE(nullptr, psu_handle);
+        auto state = lzt::get_psu_state(psu_handle);
+        EXPECT_GE(state.voltStatus, ZES_PSU_VOLTAGE_STATUS_UNKNOWN);
+        EXPECT_LE(state.voltStatus, ZES_PSU_VOLTAGE_STATUS_UNDER);
+        EXPECT_LE(state.temperature, UINT32_MAX);
+        EXPECT_LE(state.current, UINT32_MAX);
+        auto properties = lzt::get_psu_properties(psu_handle);
+        EXPECT_LE(state.current, properties.ampLimit);
+      }
+    } else {
+      LOG_INFO << "PSU handles are not available on this device!";
     }
-
-    for (auto psu_handle : psu_handles) {
-      ASSERT_NE(nullptr, psu_handle);
-      auto state = lzt::get_psu_state(psu_handle);
-      EXPECT_GE(state.voltStatus, ZES_PSU_VOLTAGE_STATUS_UNKNOWN);
-      EXPECT_LE(state.voltStatus, ZES_PSU_VOLTAGE_STATUS_UNDER);
-      EXPECT_LE(state.temperature, UINT32_MAX);
-      EXPECT_LE(state.current, UINT32_MAX);
-      auto properties = lzt::get_psu_properties(psu_handle);
-      EXPECT_LE(state.current, properties.ampLimit);
-    }
+  }
+  if (!is_psu_supported) {
+    FAIL() << "No psu handles found: "
+           << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
 } // namespace

--- a/conformance_tests/sysman/test_sysman_psu/src/test_sysman_psu.cpp
+++ b/conformance_tests/sysman/test_sysman_psu/src/test_sysman_psu.cpp
@@ -55,20 +55,11 @@ LZT_TEST_F(
         ASSERT_NE(nullptr, psu_handle);
       }
     } else {
-<<<<<<< HEAD
-      LOG_INFO << "PSU handles are not available on this device!";
+      LOG_INFO << "No psu handles found for this device!";
     }
   }
   if (!is_psu_supported) {
-    FAIL() << "No psu handles found: "
-=======
-      LOG_INFO << "No psu handles are found for this device!";
-    }
-  }
-  if (!is_psu_supported) {
-    FAIL() << "No psu handles found on any of the devices! "
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
-           << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    FAIL() << "No psu handles found on any of the devices!";
   }
 }
 
@@ -86,20 +77,11 @@ LZT_TEST_F(
       lzt::get_psu_handles(device, test_count);
       EXPECT_EQ(test_count, actual_count);
     } else {
-<<<<<<< HEAD
-      LOG_INFO << "PSU handles are not available on this device!";
+      LOG_INFO << "No psu handles found for this device!";
     }
   }
   if (!is_psu_supported) {
-    FAIL() << "No psu handles found: "
-=======
-      LOG_INFO << "No psu handles are found for this device!";
-    }
-  }
-  if (!is_psu_supported) {
-    FAIL() << "No psu handles found on any of the devices! "
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
-           << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    FAIL() << "No psu handles found on any of the devices!";
   }
 }
 
@@ -116,26 +98,18 @@ LZT_TEST_F(
       for (auto psu_handle : psu_handles_initial) {
         ASSERT_NE(nullptr, psu_handle);
       }
+      count = 0;
       auto psu_handles_later = lzt::get_psu_handles(device, count);
       for (auto psu_handle : psu_handles_later) {
         ASSERT_NE(nullptr, psu_handle);
       }
       EXPECT_EQ(psu_handles_initial, psu_handles_later);
     } else {
-<<<<<<< HEAD
-      LOG_INFO << "PSU handles are not available on this device!";
+      LOG_INFO << "No psu handles found for this device!";
     }
   }
   if (!is_psu_supported) {
-    FAIL() << "No psu devices found: "
-=======
-      LOG_INFO << "No psu handles are found for this device!";
-    }
-  }
-  if (!is_psu_supported) {
-    FAIL() << "No psu handles found on any of the devices! "
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
-           << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    FAIL() << "No psu handles found on any of the devices!";
   }
 }
 LZT_TEST_F(
@@ -158,20 +132,11 @@ LZT_TEST_F(
         }
       }
     } else {
-<<<<<<< HEAD
-      LOG_INFO << "PSU handles are not available on this device!";
+      LOG_INFO << "No psu handles found for this device!";
     }
   }
   if (!is_psu_supported) {
-    FAIL() << "No psu handles found: "
-=======
-      LOG_INFO << "No psu handles are found for this device!";
-    }
-  }
-  if (!is_psu_supported) {
-    FAIL() << "No psu handles found on any of the devices! "
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
-           << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    FAIL() << "No psu handles found on any of the devices!";
   }
 }
 
@@ -195,20 +160,11 @@ LZT_TEST_F(
         EXPECT_EQ(properties_initial.ampLimit, properties_later.ampLimit);
       }
     } else {
-<<<<<<< HEAD
-      LOG_INFO << "PSU handles are not available on this device!";
+      LOG_INFO << "No psu handles found for this device!";
     }
   }
   if (!is_psu_supported) {
-    FAIL() << "No psu handles found: "
-=======
-      LOG_INFO << "No psu handles are found for this device!";
-    }
-  }
-  if (!is_psu_supported) {
-    FAIL() << "No psu handles found on any of the devices! "
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
-           << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    FAIL() << "No psu handles found on any of the devices!";
   }
 }
 
@@ -232,20 +188,11 @@ LZT_TEST_F(PSU_TEST,
         EXPECT_LE(state.current, properties.ampLimit);
       }
     } else {
-<<<<<<< HEAD
-      LOG_INFO << "PSU handles are not available on this device!";
+      LOG_INFO << "No psu handles found for this device!";
     }
   }
   if (!is_psu_supported) {
-    FAIL() << "No psu handles found: "
-=======
-      LOG_INFO << "No psu handles are found for this device!";
-    }
-  }
-  if (!is_psu_supported) {
-    FAIL() << "No psu handles found on any of the devices! "
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
-           << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    FAIL() << "No psu handles found on any of the devices!";
   }
 }
 } // namespace

--- a/conformance_tests/sysman/test_sysman_psu/src/test_sysman_psu.cpp
+++ b/conformance_tests/sysman/test_sysman_psu/src/test_sysman_psu.cpp
@@ -55,11 +55,19 @@ LZT_TEST_F(
         ASSERT_NE(nullptr, psu_handle);
       }
     } else {
+<<<<<<< HEAD
       LOG_INFO << "PSU handles are not available on this device!";
     }
   }
   if (!is_psu_supported) {
     FAIL() << "No psu handles found: "
+=======
+      LOG_INFO << "No psu handles are found for this device!";
+    }
+  }
+  if (!is_psu_supported) {
+    FAIL() << "No psu handles found on any of the devices! "
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
            << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
@@ -78,11 +86,19 @@ LZT_TEST_F(
       lzt::get_psu_handles(device, test_count);
       EXPECT_EQ(test_count, actual_count);
     } else {
+<<<<<<< HEAD
       LOG_INFO << "PSU handles are not available on this device!";
     }
   }
   if (!is_psu_supported) {
     FAIL() << "No psu handles found: "
+=======
+      LOG_INFO << "No psu handles are found for this device!";
+    }
+  }
+  if (!is_psu_supported) {
+    FAIL() << "No psu handles found on any of the devices! "
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
            << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
@@ -106,11 +122,19 @@ LZT_TEST_F(
       }
       EXPECT_EQ(psu_handles_initial, psu_handles_later);
     } else {
+<<<<<<< HEAD
       LOG_INFO << "PSU handles are not available on this device!";
     }
   }
   if (!is_psu_supported) {
     FAIL() << "No psu devices found: "
+=======
+      LOG_INFO << "No psu handles are found for this device!";
+    }
+  }
+  if (!is_psu_supported) {
+    FAIL() << "No psu handles found on any of the devices! "
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
            << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
@@ -134,11 +158,19 @@ LZT_TEST_F(
         }
       }
     } else {
+<<<<<<< HEAD
       LOG_INFO << "PSU handles are not available on this device!";
     }
   }
   if (!is_psu_supported) {
     FAIL() << "No psu handles found: "
+=======
+      LOG_INFO << "No psu handles are found for this device!";
+    }
+  }
+  if (!is_psu_supported) {
+    FAIL() << "No psu handles found on any of the devices! "
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
            << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
@@ -163,11 +195,19 @@ LZT_TEST_F(
         EXPECT_EQ(properties_initial.ampLimit, properties_later.ampLimit);
       }
     } else {
+<<<<<<< HEAD
       LOG_INFO << "PSU handles are not available on this device!";
     }
   }
   if (!is_psu_supported) {
     FAIL() << "No psu handles found: "
+=======
+      LOG_INFO << "No psu handles are found for this device!";
+    }
+  }
+  if (!is_psu_supported) {
+    FAIL() << "No psu handles found on any of the devices! "
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
            << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
@@ -192,11 +232,19 @@ LZT_TEST_F(PSU_TEST,
         EXPECT_LE(state.current, properties.ampLimit);
       }
     } else {
+<<<<<<< HEAD
       LOG_INFO << "PSU handles are not available on this device!";
     }
   }
   if (!is_psu_supported) {
     FAIL() << "No psu handles found: "
+=======
+      LOG_INFO << "No psu handles are found for this device!";
+    }
+  }
+  if (!is_psu_supported) {
+    FAIL() << "No psu handles found on any of the devices! "
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
            << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }

--- a/conformance_tests/sysman/test_sysman_ras/src/test_sysman_ras.cpp
+++ b/conformance_tests/sysman/test_sysman_ras/src/test_sysman_ras.cpp
@@ -181,20 +181,11 @@ LZT_TEST_F(
         lzt::set_ras_config(ras_handle, rasConfigOriginal);
       }
     } else {
-<<<<<<< HEAD
-      LOG_INFO << "RAS handles are not available on this device!";
-    }
-  }
-  if (!is_ras_supported) {
-    FAIL() << "No ras handles found: "
-=======
       LOG_INFO << "No ras handles found for this device!";
     }
   }
   if (!is_ras_supported) {
-    FAIL() << "No ras handles found on any of the devices! "
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
-           << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    FAIL() << "No ras handles found on any of the devices!";
   }
 }
 
@@ -215,20 +206,11 @@ LZT_TEST_F(RAS_TEST,
         validate_ras_state(rasState);
       }
     } else {
-<<<<<<< HEAD
-      LOG_INFO << "RAS handles are not available on this device!";
-    }
-  }
-  if (!is_ras_supported) {
-    FAIL() << "No ras handles found: "
-=======
       LOG_INFO << "No ras handles found for this device!";
     }
   }
   if (!is_ras_supported) {
-    FAIL() << "No ras handles found on any of the devices! "
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
-           << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    FAIL() << "No ras handles found on any of the devices!";
   }
 }
 
@@ -257,20 +239,11 @@ LZT_TEST_F(
         EXPECT_GE(tErrorsinitial, tErrorsAfterClear);
       }
     } else {
-<<<<<<< HEAD
-      LOG_INFO << "RAS handles are not available on this device!";
-    }
-  }
-  if (!is_ras_supported) {
-    FAIL() << "No ras handles found: "
-=======
       LOG_INFO << "No ras handles found for this device!";
     }
   }
   if (!is_ras_supported) {
-    FAIL() << "No ras handles found on any of the devices! "
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
-           << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    FAIL() << "No ras handles found on any of the devices!";
   }
 }
 
@@ -300,20 +273,11 @@ LZT_TEST_F(
         }
       }
     } else {
-<<<<<<< HEAD
-      LOG_INFO << "RAS handles are not available on this device!";
-    }
-  }
-  if (!is_ras_supported) {
-    FAIL() << "No ras handles found: "
-=======
       LOG_INFO << "No ras handles found for this device!";
     }
   }
   if (!is_ras_supported) {
-    FAIL() << "No ras handles found on any of the devices! "
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
-           << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    FAIL() << "No ras handles found on any of the devices!";
   }
 }
 
@@ -331,20 +295,11 @@ LZT_TEST_F(
         ASSERT_NE(nullptr, ras_handle);
       }
     } else {
-<<<<<<< HEAD
-      LOG_INFO << "RAS handles are not available on this device!";
-    }
-  }
-  if (!is_ras_supported) {
-    FAIL() << "No ras handles found: "
-=======
       LOG_INFO << "No ras handles found for this device!";
     }
   }
   if (!is_ras_supported) {
-    FAIL() << "No ras handles found on any of the devices! "
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
-           << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    FAIL() << "No ras handles found on any of the devices!";
   }
 }
 
@@ -356,11 +311,7 @@ LZT_TEST_F(
     count = lzt::get_ras_handles_count(device);
     if (count > 0) {
       is_ras_supported = true;
-<<<<<<< HEAD
       LOG_INFO << "RAS handles are  available on this device!";
-=======
-      LOG_INFO << "RAS handles are available on this device!";
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
       auto ras_handles = lzt::get_ras_handles(device, count);
       for (auto ras_handle : ras_handles) {
         ASSERT_NE(nullptr, ras_handle);
@@ -370,20 +321,11 @@ LZT_TEST_F(
         }
       }
     } else {
-<<<<<<< HEAD
-      LOG_INFO << "RAS handles are not available on this device!";
-    }
-  }
-  if (!is_ras_supported) {
-    FAIL() << "No ras handles found: "
-=======
       LOG_INFO << "No ras handles found for this device!";
     }
   }
   if (!is_ras_supported) {
-    FAIL() << "No ras handles found on any of the devices! "
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
-           << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    FAIL() << "No ras handles found on any of the devices!";
   }
 }
 
@@ -415,20 +357,11 @@ LZT_TEST_F(
         EXPECT_LE(errors_after_clear, initial_errors);
       }
     } else {
-<<<<<<< HEAD
-      LOG_INFO << "RAS handles are not available on this device!";
-    }
-  }
-  if (!is_ras_supported) {
-    FAIL() << "No ras devices found: "
-=======
       LOG_INFO << "No ras handles found for this device!";
     }
   }
   if (!is_ras_supported) {
-    FAIL() << "No ras handles found on any of the devices! "
->>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
-           << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    FAIL() << "No ras handles found on any of the devices!";
   }
 }
 } // namespace

--- a/conformance_tests/sysman/test_sysman_ras/src/test_sysman_ras.cpp
+++ b/conformance_tests/sysman/test_sysman_ras/src/test_sysman_ras.cpp
@@ -181,11 +181,19 @@ LZT_TEST_F(
         lzt::set_ras_config(ras_handle, rasConfigOriginal);
       }
     } else {
+<<<<<<< HEAD
       LOG_INFO << "RAS handles are not available on this device!";
     }
   }
   if (!is_ras_supported) {
     FAIL() << "No ras handles found: "
+=======
+      LOG_INFO << "No ras handles found for this device!";
+    }
+  }
+  if (!is_ras_supported) {
+    FAIL() << "No ras handles found on any of the devices! "
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
            << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
@@ -207,11 +215,19 @@ LZT_TEST_F(RAS_TEST,
         validate_ras_state(rasState);
       }
     } else {
+<<<<<<< HEAD
       LOG_INFO << "RAS handles are not available on this device!";
     }
   }
   if (!is_ras_supported) {
     FAIL() << "No ras handles found: "
+=======
+      LOG_INFO << "No ras handles found for this device!";
+    }
+  }
+  if (!is_ras_supported) {
+    FAIL() << "No ras handles found on any of the devices! "
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
            << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
@@ -241,11 +257,19 @@ LZT_TEST_F(
         EXPECT_GE(tErrorsinitial, tErrorsAfterClear);
       }
     } else {
+<<<<<<< HEAD
       LOG_INFO << "RAS handles are not available on this device!";
     }
   }
   if (!is_ras_supported) {
     FAIL() << "No ras handles found: "
+=======
+      LOG_INFO << "No ras handles found for this device!";
+    }
+  }
+  if (!is_ras_supported) {
+    FAIL() << "No ras handles found on any of the devices! "
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
            << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
@@ -276,11 +300,19 @@ LZT_TEST_F(
         }
       }
     } else {
+<<<<<<< HEAD
       LOG_INFO << "RAS handles are not available on this device!";
     }
   }
   if (!is_ras_supported) {
     FAIL() << "No ras handles found: "
+=======
+      LOG_INFO << "No ras handles found for this device!";
+    }
+  }
+  if (!is_ras_supported) {
+    FAIL() << "No ras handles found on any of the devices! "
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
            << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
@@ -299,11 +331,19 @@ LZT_TEST_F(
         ASSERT_NE(nullptr, ras_handle);
       }
     } else {
+<<<<<<< HEAD
       LOG_INFO << "RAS handles are not available on this device!";
     }
   }
   if (!is_ras_supported) {
     FAIL() << "No ras handles found: "
+=======
+      LOG_INFO << "No ras handles found for this device!";
+    }
+  }
+  if (!is_ras_supported) {
+    FAIL() << "No ras handles found on any of the devices! "
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
            << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
@@ -316,7 +356,11 @@ LZT_TEST_F(
     count = lzt::get_ras_handles_count(device);
     if (count > 0) {
       is_ras_supported = true;
+<<<<<<< HEAD
       LOG_INFO << "RAS handles are  available on this device!";
+=======
+      LOG_INFO << "RAS handles are available on this device!";
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
       auto ras_handles = lzt::get_ras_handles(device, count);
       for (auto ras_handle : ras_handles) {
         ASSERT_NE(nullptr, ras_handle);
@@ -326,11 +370,19 @@ LZT_TEST_F(
         }
       }
     } else {
+<<<<<<< HEAD
       LOG_INFO << "RAS handles are not available on this device!";
     }
   }
   if (!is_ras_supported) {
     FAIL() << "No ras handles found: "
+=======
+      LOG_INFO << "No ras handles found for this device!";
+    }
+  }
+  if (!is_ras_supported) {
+    FAIL() << "No ras handles found on any of the devices! "
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
            << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }
@@ -363,11 +415,19 @@ LZT_TEST_F(
         EXPECT_LE(errors_after_clear, initial_errors);
       }
     } else {
+<<<<<<< HEAD
       LOG_INFO << "RAS handles are not available on this device!";
     }
   }
   if (!is_ras_supported) {
     FAIL() << "No ras devices found: "
+=======
+      LOG_INFO << "No ras handles found for this device!";
+    }
+  }
+  if (!is_ras_supported) {
+    FAIL() << "No ras handles found on any of the devices! "
+>>>>>>> 466a087 (Primary JIRA: VLCJ-2513)
            << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
   }
 }

--- a/utils/test_harness/sysman/include/test_harness_sysman_ras.hpp
+++ b/utils/test_harness/sysman/include/test_harness_sysman_ras.hpp
@@ -12,7 +12,7 @@
 #include <level_zero/zes_api.h>
 #include "gtest/gtest.h"
 namespace level_zero_tests {
-
+uint32_t get_ras_handles_count(zes_device_handle_t device);
 std::vector<zes_ras_handle_t> get_ras_handles(zes_device_handle_t device,
                                               uint32_t &count);
 zes_ras_properties_t get_ras_properties(zes_ras_handle_t rasHandle);


### PR DESCRIPTION
Primary JIRA: VLCJ-2513
Sub-tasks: VLCLJ-2572, VLCLJ-2575, VLCLJ-2564
Update the GTEST_FAIL logic for led, memory and firmware devices. Implemented to check the handles for all the devices and FAIL only if the handle is not found for any device.