### PR TITLE
Fix: Handling GTEST_FAIL logic for multi-device scenario for LED, Memory and Firmware modules

### DIFF
--- a/conformance_tests/sysman/test_sysman_firmware/src/test_sysman_firmware.cpp
+++ b/conformance_tests/sysman/test_sysman_firmware/src/test_sysman_firmware.cpp
@@ -183,7 +183,7 @@ LZT_TEST_F(
     count = lzt::get_firmware_handle_count(device);
     if (count > 0) {
       is_firmware_supported = true;
-      LOG_INFO << "Firnware handles are available on this device! ";
+      LOG_INFO << "Firmware handles are available on this device! ";
       auto firmware_handles = lzt::get_firmware_handles(device, count);
       for (auto firmware_handle : firmware_handles) {
         ASSERT_NE(nullptr, firmware_handle);
@@ -283,9 +283,10 @@ LZT_TEST_F(
   std::string fw_dir(fw_dir_env);
   for (auto device : devices) {
     uint32_t count = 0;
+    count = lzt::get_firmware_handle_count(device);
     if (count > 0) {
       is_firmware_supported = true;
-      LOG_INFO << "Firnware handles are available on this device! ";
+      LOG_INFO << "Firmware handles are available on this device! ";
       auto firmware_handles = lzt::get_firmware_handles(device, count);
       for (auto firmware_handle : firmware_handles) {
         std::thread firmware_flasher(flash_firmware, firmware_handle, fw_dir);

--- a/conformance_tests/sysman/test_sysman_firmware/src/test_sysman_firmware.cpp
+++ b/conformance_tests/sysman/test_sysman_firmware/src/test_sysman_firmware.cpp
@@ -26,10 +26,16 @@ namespace {
 uint32_t get_prop_length(char *prop) { return std::strlen(prop); }
 
 #ifdef USE_ZESINIT
-class FirmwareZesTest : public lzt::ZesSysmanCtsClass {};
+class FirmwareZesTest : public lzt::ZesSysmanCtsClass {
+public:
+  bool is_firmware_supported = false;
+};
 #define FIRMWARE_TEST FirmwareZesTest
 #else // USE_ZESINIT
-class FirmwareTest : public lzt::SysmanCtsClass {};
+class FirmwareTest : public lzt::SysmanCtsClass {
+public:
+  bool is_firmware_supported = false;
+};
 #define FIRMWARE_TEST FirmwareTest
 #endif // USE_ZESINIT
 
@@ -39,10 +45,15 @@ LZT_TEST_F(
   for (auto device : devices) {
     uint32_t count = 0;
     count = lzt::get_firmware_handle_count(device);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    if (count > 0) {
+      is_firmware_supported = true;
+      LOG_INFO << "Firmware handles are available on this device! ";
+    } else {
+      LOG_INFO << "No firmware handles found for this device! ";
     }
+  }
+  if (!is_firmware_supported) {
+    FAIL() << "No firmware handles found on any of the devices! ";
   }
 }
 LZT_TEST_F(
@@ -50,16 +61,21 @@ LZT_TEST_F(
     GivenComponentCountZeroWhenRetrievingFirmwareHandlesThenNotNullFirmwareHandlesAreReturned) {
   for (auto device : devices) {
     uint32_t count = 0;
-    auto firmware_handles = lzt::get_firmware_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    count = lzt::get_firmware_handle_count(device);
+    if (count > 0) {
+      is_firmware_supported = true;
+      LOG_INFO << "Firmware handles are available on this device! ";
+      auto firmware_handles = lzt::get_firmware_handles(device, count);
+      ASSERT_EQ(firmware_handles.size(), count);
+      for (auto firmware_handle : firmware_handles) {
+        ASSERT_NE(nullptr, firmware_handle);
+      }
+    } else {
+      LOG_INFO << "No firmware handles found for this device! ";
     }
-
-    ASSERT_EQ(firmware_handles.size(), count);
-    for (auto firmware_handle : firmware_handles) {
-      ASSERT_NE(nullptr, firmware_handle);
-    }
+  }
+  if (!is_firmware_supported) {
+    FAIL() << "No firmware handles found on any of the devices! ";
   }
 }
 
@@ -68,15 +84,20 @@ LZT_TEST_F(
     GivenInvalidComponentCountWhenRetrievingSysmanFirmwareHandlesThenActualComponentCountIsUpdated) {
   for (auto device : devices) {
     uint32_t actual_count = 0;
-    auto firmware_handles = lzt::get_firmware_handles(device, actual_count);
-    if (actual_count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    actual_count = lzt::get_firmware_handle_count(device);
+    if (actual_count > 0) {
+      is_firmware_supported = true;
+      LOG_INFO << "Firmware handles are available on this device! ";
+      auto firmware_handles = lzt::get_firmware_handles(device, actual_count);
+      uint32_t test_count = actual_count + 1;
+      firmware_handles = lzt::get_firmware_handles(device, test_count);
+      EXPECT_EQ(test_count, actual_count);
+    } else {
+      LOG_INFO << "No firmware handles found for this device! ";
     }
-
-    uint32_t test_count = actual_count + 1;
-    firmware_handles = lzt::get_firmware_handles(device, test_count);
-    EXPECT_EQ(test_count, actual_count);
+  }
+  if (!is_firmware_supported) {
+    FAIL() << "No firmware handles found on any of the devices! ";
   }
 }
 LZT_TEST_F(
@@ -85,22 +106,28 @@ LZT_TEST_F(
   for (auto device : devices) {
     auto deviceProperties = lzt::get_sysman_device_properties(device);
     uint32_t count = 0;
-    auto firmware_handles = lzt::get_firmware_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
-    }
-
-    for (auto firmware_handle : firmware_handles) {
-      ASSERT_NE(nullptr, firmware_handle);
-      auto properties = lzt::get_firmware_properties(firmware_handle);
-      if (properties.onSubdevice) {
-        EXPECT_LT(properties.subdeviceId, deviceProperties.numSubdevices);
+    count = lzt::get_firmware_handle_count(device);
+    if (count > 0) {
+      is_firmware_supported = true;
+      LOG_INFO << "Firmware handles are available on this device! ";
+      auto firmware_handles = lzt::get_firmware_handles(device, count);
+      for (auto firmware_handle : firmware_handles) {
+        ASSERT_NE(nullptr, firmware_handle);
+        auto properties = lzt::get_firmware_properties(firmware_handle);
+        if (properties.onSubdevice) {
+          EXPECT_LT(properties.subdeviceId, deviceProperties.numSubdevices);
+        }
+        EXPECT_LT(get_prop_length(properties.name), ZES_STRING_PROPERTY_SIZE);
+        EXPECT_GT(get_prop_length(properties.name), 0);
+        EXPECT_LT(get_prop_length(properties.version),
+                  ZES_STRING_PROPERTY_SIZE);
       }
-      EXPECT_LT(get_prop_length(properties.name), ZES_STRING_PROPERTY_SIZE);
-      EXPECT_GT(get_prop_length(properties.name), 0);
-      EXPECT_LT(get_prop_length(properties.version), ZES_STRING_PROPERTY_SIZE);
+    } else {
+      LOG_INFO << "No firmware handles found for this device! ";
     }
+  }
+  if (!is_firmware_supported) {
+    FAIL() << "No firmware handles found on any of the devices! ";
   }
 }
 
@@ -109,28 +136,35 @@ LZT_TEST_F(
     GivenValidFirmwareHandleWhenRetrievingFirmwarePropertiesThenExpectSamePropertiesReturnedTwice) {
   for (auto device : devices) {
     uint32_t count = 0;
-    auto firmware_handles = lzt::get_firmware_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
-    }
-
-    for (auto firmware_handle : firmware_handles) {
-      ASSERT_NE(nullptr, firmware_handle);
-      auto properties_initial = lzt::get_firmware_properties(firmware_handle);
-      auto properties_later = lzt::get_firmware_properties(firmware_handle);
-      EXPECT_EQ(properties_initial.onSubdevice, properties_later.onSubdevice);
-      if (properties_initial.onSubdevice && properties_later.onSubdevice) {
-        EXPECT_EQ(properties_initial.subdeviceId, properties_later.subdeviceId);
+    count = lzt::get_firmware_handle_count(device);
+    if (count > 0) {
+      is_firmware_supported = true;
+      LOG_INFO << "Firmware handles are available on this device! ";
+      auto firmware_handles = lzt::get_firmware_handles(device, count);
+      for (auto firmware_handle : firmware_handles) {
+        ASSERT_NE(nullptr, firmware_handle);
+        auto properties_initial = lzt::get_firmware_properties(firmware_handle);
+        auto properties_later = lzt::get_firmware_properties(firmware_handle);
+        EXPECT_EQ(properties_initial.onSubdevice, properties_later.onSubdevice);
+        if (properties_initial.onSubdevice && properties_later.onSubdevice) {
+          EXPECT_EQ(properties_initial.subdeviceId,
+                    properties_later.subdeviceId);
+        }
+        EXPECT_TRUE(
+            0 == std::strcmp(reinterpret_cast<char *>(properties_initial.name),
+                             reinterpret_cast<char *>(properties_later.name)));
+        EXPECT_TRUE(
+            0 ==
+            std::strcmp(reinterpret_cast<char *>(properties_initial.version),
+                        reinterpret_cast<char *>(properties_later.version)));
+        EXPECT_EQ(properties_initial.canControl, properties_later.canControl);
       }
-      EXPECT_TRUE(0 ==
-                  std::strcmp(reinterpret_cast<char *>(properties_initial.name),
-                              reinterpret_cast<char *>(properties_later.name)));
-      EXPECT_TRUE(
-          0 == std::strcmp(reinterpret_cast<char *>(properties_initial.version),
-                           reinterpret_cast<char *>(properties_later.version)));
-      EXPECT_EQ(properties_initial.canControl, properties_later.canControl);
+    } else {
+      LOG_INFO << "No firmware handles found for this device! ";
     }
+  }
+  if (!is_firmware_supported) {
+    FAIL() << "No firmware handles found on any of the devices! ";
   }
 }
 
@@ -146,31 +180,37 @@ LZT_TEST_F(
   std::string fwDir(fwDirEnv);
   for (auto device : devices) {
     uint32_t count = 0;
-    auto firmware_handles = lzt::get_firmware_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
-    }
-
-    for (auto firmware_handle : firmware_handles) {
-      ASSERT_NE(nullptr, firmware_handle);
-      auto propFw = lzt::get_firmware_properties(firmware_handle);
-      if (propFw.canControl == true) {
-        std::string fwName(reinterpret_cast<char *>(propFw.name));
-        std::string fwToLoad = fwDir + "/" + fwName + ".bin";
-        std::ifstream inFileStream(fwToLoad, std::ios::binary | std::ios::ate);
-        if (!inFileStream.is_open()) {
-          LOG_INFO << "Skipping test as firmware image not found";
-          GTEST_SKIP();
+    count = lzt::get_firmware_handle_count(device);
+    if (count > 0) {
+      is_firmware_supported = true;
+      LOG_INFO << "Firnware handles are available on this device! ";
+      auto firmware_handles = lzt::get_firmware_handles(device, count);
+      for (auto firmware_handle : firmware_handles) {
+        ASSERT_NE(nullptr, firmware_handle);
+        auto propFw = lzt::get_firmware_properties(firmware_handle);
+        if (propFw.canControl == true) {
+          std::string fwName(reinterpret_cast<char *>(propFw.name));
+          std::string fwToLoad = fwDir + "/" + fwName + ".bin";
+          std::ifstream inFileStream(fwToLoad,
+                                     std::ios::binary | std::ios::ate);
+          if (!inFileStream.is_open()) {
+            LOG_INFO << "Skipping test as firmware image not found";
+            GTEST_SKIP();
+          }
+          testFwImage.resize(inFileStream.tellg());
+          inFileStream.seekg(0, inFileStream.beg);
+          inFileStream.read(testFwImage.data(), testFwImage.size());
+          lzt::flash_firmware(firmware_handle,
+                              static_cast<void *>(testFwImage.data()),
+                              testFwImage.size());
         }
-        testFwImage.resize(inFileStream.tellg());
-        inFileStream.seekg(0, inFileStream.beg);
-        inFileStream.read(testFwImage.data(), testFwImage.size());
-        lzt::flash_firmware(firmware_handle,
-                            static_cast<void *>(testFwImage.data()),
-                            testFwImage.size());
       }
+    } else {
+      LOG_INFO << "No firmware handles found for this device! ";
     }
+  }
+  if (!is_firmware_supported) {
+    FAIL() << "No firmware handles found on any of the devices! ";
   }
 }
 
@@ -243,19 +283,22 @@ LZT_TEST_F(
   std::string fw_dir(fw_dir_env);
   for (auto device : devices) {
     uint32_t count = 0;
-    auto firmware_handles = lzt::get_firmware_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    if (count > 0) {
+      is_firmware_supported = true;
+      LOG_INFO << "Firnware handles are available on this device! ";
+      auto firmware_handles = lzt::get_firmware_handles(device, count);
+      for (auto firmware_handle : firmware_handles) {
+        std::thread firmware_flasher(flash_firmware, firmware_handle, fw_dir);
+        std::thread progress_tracker(track_firmware_flash, firmware_handle);
+        firmware_flasher.join();
+        progress_tracker.join();
+      }
+    } else {
+      LOG_INFO << "No firmware handles found for this device! ";
     }
-
-    for (auto firmware_handle : firmware_handles) {
-      std::thread firmware_flasher(flash_firmware, firmware_handle, fw_dir);
-      std::thread progress_tracker(track_firmware_flash, firmware_handle);
-
-      firmware_flasher.join();
-      progress_tracker.join();
-    }
+  }
+  if (!is_firmware_supported) {
+    FAIL() << "No firmware handles found on any of the devices! ";
   }
 }
 

--- a/conformance_tests/sysman/test_sysman_led/src/test_sysman_led.cpp
+++ b/conformance_tests/sysman/test_sysman_led/src/test_sysman_led.cpp
@@ -20,10 +20,16 @@ namespace lzt = level_zero_tests;
 namespace {
 
 #ifdef USE_ZESINIT
-class LedModuleZesTest : public lzt::ZesSysmanCtsClass {};
+class LedModuleZesTest : public lzt::ZesSysmanCtsClass {
+public:
+  bool is_led_supported = false;
+};
 #define LED_TEST LedModuleZesTest
 #else // USE_ZESINIT
-class LedModuleTest : public lzt::SysmanCtsClass {};
+class LedModuleTest : public lzt::SysmanCtsClass {
+public:
+  bool is_led_supported = false;
+};
 #define LED_TEST LedModuleTest
 #endif // USE_ZESINIT
 
@@ -40,16 +46,21 @@ LZT_TEST_F(
     GivenComponentCountZeroWhenRetrievingSysmanHandlesThenNotNullLedHandlesAreReturned) {
   for (auto device : devices) {
     uint32_t count = 0;
-    auto led_handles = lzt::get_led_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    count = lzt::get_led_handle_count(device);
+    if (count > 0) {
+      is_led_supported = true;
+      LOG_INFO << "Led handles are available on this device!";
+      auto led_handles = lzt::get_led_handles(device, count);
+      ASSERT_EQ(led_handles.size(), count);
+      for (auto led_handle : led_handles) {
+        ASSERT_NE(nullptr, led_handle);
+      }
+    } else {
+      LOG_INFO << "No led handles found for this device!";
     }
-
-    ASSERT_EQ(led_handles.size(), count);
-    for (auto led_handle : led_handles) {
-      ASSERT_NE(nullptr, led_handle);
-    }
+  }
+  if (!is_led_supported) {
+    FAIL() << "No led handles found on any of the devices! ";
   }
 }
 
@@ -58,15 +69,20 @@ LZT_TEST_F(
     GivenInvalidComponentCountWhenRetrievingSysmanHandlesThenActualComponentCountIsUpdated) {
   for (auto device : devices) {
     uint32_t actual_count = 0;
-    lzt::get_led_handles(device, actual_count);
-    if (actual_count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    actual_count = lzt::get_led_handle_count(device);
+    if (actual_count > 0) {
+      is_led_supported = true;
+      LOG_INFO << "Led handles are available on this device!";
+      lzt::get_led_handles(device, actual_count);
+      uint32_t test_count = actual_count + 1;
+      lzt::get_led_handles(device, test_count);
+      EXPECT_EQ(test_count, actual_count);
+    } else {
+      LOG_INFO << "No led handles found for this device!";
     }
-
-    uint32_t test_count = actual_count + 1;
-    lzt::get_led_handles(device, test_count);
-    EXPECT_EQ(test_count, actual_count);
+  }
+  if (!is_led_supported) {
+    FAIL() << "No led handles found on any of the devices! ";
   }
 }
 
@@ -75,22 +91,26 @@ LZT_TEST_F(
     GivenValidComponentCountWhenCallingApiTwiceThenSimilarLedHandlesReturned) {
   for (auto device : devices) {
     uint32_t count = 0;
-    auto led_handles_initial = lzt::get_led_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    count = lzt::get_led_handle_count(device);
+    if (count > 0) {
+      is_led_supported = true;
+      LOG_INFO << "Led handles are available on this device!";
+      auto led_handles_initial = lzt::get_led_handles(device, count);
+      for (auto led_handle : led_handles_initial) {
+        ASSERT_NE(nullptr, led_handle);
+      }
+      count = 0;
+      auto led_handles_later = lzt::get_led_handles(device, count);
+      for (auto led_handle : led_handles_later) {
+        ASSERT_NE(nullptr, led_handle);
+      }
+      EXPECT_EQ(led_handles_initial, led_handles_later);
+    } else {
+      LOG_INFO << "No led handles found for this device! ";
     }
-
-    for (auto led_handle : led_handles_initial) {
-      ASSERT_NE(nullptr, led_handle);
-    }
-
-    count = 0;
-    auto led_handles_later = lzt::get_led_handles(device, count);
-    for (auto led_handle : led_handles_later) {
-      ASSERT_NE(nullptr, led_handle);
-    }
-    EXPECT_EQ(led_handles_initial, led_handles_later);
+  }
+  if (!is_led_supported) {
+    FAIL() << "No led handles found on any of the devices! ";
   }
 }
 
@@ -100,19 +120,24 @@ LZT_TEST_F(
   for (auto device : devices) {
     auto deviceProperties = lzt::get_sysman_device_properties(device);
     uint32_t count = 0;
-    auto led_handles = lzt::get_led_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
-    }
-
-    for (auto led_handle : led_handles) {
-      ASSERT_NE(nullptr, led_handle);
-      auto properties = lzt::get_led_properties(led_handle);
-      if (properties.onSubdevice) {
-        EXPECT_LT(properties.subdeviceId, deviceProperties.numSubdevices);
+    count = lzt::get_led_handle_count(device);
+    if (count > 0) {
+      is_led_supported = true;
+      LOG_INFO << "Led handles are available on this device!";
+      auto led_handles = lzt::get_led_handles(device, count);
+      for (auto led_handle : led_handles) {
+        ASSERT_NE(nullptr, led_handle);
+        auto properties = lzt::get_led_properties(led_handle);
+        if (properties.onSubdevice) {
+          EXPECT_LT(properties.subdeviceId, deviceProperties.numSubdevices);
+        }
       }
+    } else {
+      LOG_INFO << "No led handles found for this device! ";
     }
+  }
+  if (!is_led_supported) {
+    FAIL() << "No led handles found on any of the devices! ";
   }
 }
 
@@ -121,105 +146,126 @@ LZT_TEST_F(
     GivenValidLedHandleWhenRetrievingLedPropertiesThenExpectSamePropertiesReturnedTwice) {
   for (auto device : devices) {
     uint32_t count = 0;
-    auto led_handles = lzt::get_led_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
-    }
-
-    for (auto led_handle : led_handles) {
-      ASSERT_NE(nullptr, led_handle);
-      auto properties_initial = lzt::get_led_properties(led_handle);
-      auto properties_later = lzt::get_led_properties(led_handle);
-      EXPECT_EQ(properties_initial.canControl, properties_later.canControl);
-      if (properties_initial.onSubdevice && properties_later.onSubdevice) {
-        EXPECT_EQ(properties_initial.subdeviceId, properties_later.subdeviceId);
+    count = lzt::get_led_handle_count(device);
+    if (count > 0) {
+      is_led_supported = true;
+      LOG_INFO << "Led handles are available on this device!";
+      auto led_handles = lzt::get_led_handles(device, count);
+      for (auto led_handle : led_handles) {
+        ASSERT_NE(nullptr, led_handle);
+        auto properties_initial = lzt::get_led_properties(led_handle);
+        auto properties_later = lzt::get_led_properties(led_handle);
+        EXPECT_EQ(properties_initial.canControl, properties_later.canControl);
+        if (properties_initial.onSubdevice && properties_later.onSubdevice) {
+          EXPECT_EQ(properties_initial.subdeviceId,
+                    properties_later.subdeviceId);
+        }
+        EXPECT_EQ(properties_initial.haveRGB, properties_later.haveRGB);
       }
-      EXPECT_EQ(properties_initial.haveRGB, properties_later.haveRGB);
+    } else {
+      LOG_INFO << "No led handles found for this device! ";
     }
+  }
+  if (!is_led_supported) {
+    FAIL() << "No led handles found on any of the devices! ";
   }
 }
 LZT_TEST_F(LED_TEST,
            GivenValidLedHandleWhenRetrievingLedStateThenValidStateIsReturned) {
   for (auto device : devices) {
     uint32_t count = 0;
-    auto led_handles = lzt::get_led_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
-    }
-
-    for (auto led_handle : led_handles) {
-      ASSERT_NE(nullptr, led_handle);
-      auto properties = lzt::get_led_properties(led_handle);
-      auto state = lzt::get_led_state(led_handle);
-      if (state.isOn == false) {
-        ASSERT_DOUBLE_EQ(state.color.red, 0.0);
-        ASSERT_DOUBLE_EQ(state.color.green, 0.0);
-        ASSERT_DOUBLE_EQ(state.color.blue, 0.0);
-      } else {
-        if ((state.color.red == 0.0) && (state.color.green == 0.0) &&
-            (state.color.blue == 0.0))
-          FAIL();
-        else
-          SUCCEED();
+    count = lzt::get_led_handle_count(device);
+    if (count > 0) {
+      is_led_supported = true;
+      LOG_INFO << "Led handles are available on this device!";
+      auto led_handles = lzt::get_led_handles(device, count);
+      for (auto led_handle : led_handles) {
+        ASSERT_NE(nullptr, led_handle);
+        auto properties = lzt::get_led_properties(led_handle);
+        auto state = lzt::get_led_state(led_handle);
+        if (state.isOn == false) {
+          ASSERT_DOUBLE_EQ(state.color.red, 0.0);
+          ASSERT_DOUBLE_EQ(state.color.green, 0.0);
+          ASSERT_DOUBLE_EQ(state.color.blue, 0.0);
+        } else {
+          if ((state.color.red == 0.0) && (state.color.green == 0.0) &&
+              (state.color.blue == 0.0))
+            FAIL();
+          else
+            SUCCEED();
+        }
       }
+    } else {
+      LOG_INFO << "No led handles found for this device! ";
     }
+  }
+  if (!is_led_supported) {
+    FAIL() << "No led handles found on any of the devices! ";
   }
 }
 LZT_TEST_F(LED_TEST,
            GivenValidLedHandleWhenSettingLedColorTheSuccessIsReturned) {
   for (auto device : devices) {
     uint32_t count = 0;
-    auto led_handles = lzt::get_led_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
-    }
-
-    for (auto led_handle : led_handles) {
-      ASSERT_NE(nullptr, led_handle);
-      auto initial_state = lzt::get_led_state(led_handle);
-      if (initial_state.isOn == false) {
-        lzt::set_led_state(led_handle, true);
+    count = lzt::get_led_handle_count(device);
+    if (count > 0) {
+      is_led_supported = true;
+      LOG_INFO << "Led handles are available on this device!";
+      auto led_handles = lzt::get_led_handles(device, count);
+      for (auto led_handle : led_handles) {
+        ASSERT_NE(nullptr, led_handle);
+        auto initial_state = lzt::get_led_state(led_handle);
+        if (initial_state.isOn == false) {
+          lzt::set_led_state(led_handle, true);
+        }
+        zes_led_color_t color = {};
+        color.red = 1.0;
+        color.blue = 1.0;
+        color.green = 1.0;
+        lzt::set_led_color(led_handle, color);
+        zes_led_state_t get_state = lzt::get_led_state(led_handle);
+        EXPECT_EQ(get_state.isOn, true);
+        EXPECT_DOUBLE_EQ(get_state.color.red, 1.0);
+        EXPECT_DOUBLE_EQ(get_state.color.blue, 1.0);
+        EXPECT_DOUBLE_EQ(get_state.color.green, 1.0);
+        color.red = initial_state.color.red;
+        color.blue = initial_state.color.blue;
+        color.green = initial_state.color.green;
+        lzt::set_led_color(led_handle, color);
       }
-      zes_led_color_t color = {};
-      color.red = 1.0;
-      color.blue = 1.0;
-      color.green = 1.0;
-      lzt::set_led_color(led_handle, color);
-      zes_led_state_t get_state = lzt::get_led_state(led_handle);
-      EXPECT_EQ(get_state.isOn, true);
-      EXPECT_DOUBLE_EQ(get_state.color.red, 1.0);
-      EXPECT_DOUBLE_EQ(get_state.color.blue, 1.0);
-      EXPECT_DOUBLE_EQ(get_state.color.green, 1.0);
-      color.red = initial_state.color.red;
-      color.blue = initial_state.color.blue;
-      color.green = initial_state.color.green;
-      lzt::set_led_color(led_handle, color);
+    } else {
+      LOG_INFO << "No led handles found for this device! ";
     }
+  }
+  if (!is_led_supported) {
+    FAIL() << "No led handles found on any of the devices! ";
   }
 }
 LZT_TEST_F(LED_TEST,
            GivenValidLedHandleWhenSettingLedStateToOffThenSuccessIsReturned) {
   for (auto device : devices) {
     uint32_t count = 0;
-    auto led_handles = lzt::get_led_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    count = lzt::get_led_handle_count(device);
+    if (count > 0) {
+      is_led_supported = true;
+      LOG_INFO << "Led handles are available on this device!";
+      auto led_handles = lzt::get_led_handles(device, count);
+      for (auto led_handle : led_handles) {
+        ASSERT_NE(nullptr, led_handle);
+        lzt::set_led_state(led_handle, false);
+        auto get_state = lzt::get_led_state(led_handle);
+        EXPECT_EQ(get_state.isOn, false);
+        EXPECT_DOUBLE_EQ(get_state.color.red, 0.0);
+        EXPECT_DOUBLE_EQ(get_state.color.blue, 0.0);
+        EXPECT_DOUBLE_EQ(get_state.color.green, 0.0);
+        lzt::set_led_state(led_handle, true);
+      }
+    } else {
+      LOG_INFO << "No led handles found for this device! ";
     }
-
-    for (auto led_handle : led_handles) {
-      ASSERT_NE(nullptr, led_handle);
-      lzt::set_led_state(led_handle, false);
-      auto get_state = lzt::get_led_state(led_handle);
-      EXPECT_EQ(get_state.isOn, false);
-      EXPECT_DOUBLE_EQ(get_state.color.red, 0.0);
-      EXPECT_DOUBLE_EQ(get_state.color.blue, 0.0);
-      EXPECT_DOUBLE_EQ(get_state.color.green, 0.0);
-      lzt::set_led_state(led_handle, true);
-    }
+  }
+  if (!is_led_supported) {
+    FAIL() << "No led handles found on any of the devices! ";
   }
 }
 

--- a/conformance_tests/sysman/test_sysman_memory/src/test_sysman_memory.cpp
+++ b/conformance_tests/sysman/test_sysman_memory/src/test_sysman_memory.cpp
@@ -20,10 +20,16 @@ namespace lzt = level_zero_tests;
 namespace {
 
 #ifdef USE_ZESINIT
-class MemoryModuleZesTest : public lzt::ZesSysmanCtsClass {};
+class MemoryModuleZesTest : public lzt::ZesSysmanCtsClass {
+public:
+  bool is_mem_supported = false;
+};
 #define MEMORY_TEST MemoryModuleZesTest
 #else // USE_ZESINIT
-class MemoryModuleTest : public lzt::SysmanCtsClass {};
+class MemoryModuleTest : public lzt::SysmanCtsClass {
+public:
+  bool is_mem_supported = false;
+};
 #define MEMORY_TEST MemoryModuleTest
 #endif // USE_ZESINIT
 
@@ -32,11 +38,17 @@ LZT_TEST_F(
     GivenComponentCountZeroWhenRetrievingSysmanHandlesThenNonZeroCountIsReturned) {
   for (auto device : devices) {
     uint32_t count = 0;
-    auto mem_handles = lzt::get_mem_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    count = lzt::get_mem_handle_count(device);
+    if (count > 0) {
+      is_mem_supported = true;
+      LOG_INFO << "Memory handles are available on this device! ";
+      auto mem_handles = lzt::get_mem_handles(device, count);
+    } else {
+      LOG_INFO << "No memory handles found for this device! ";
     }
+  }
+  if (!is_mem_supported) {
+    FAIL() << "No memory handles found on any of the devices! ";
   }
 }
 
@@ -45,16 +57,21 @@ LZT_TEST_F(
     GivenComponentCountZeroWhenRetrievingSysmanHandlesThenNotNullMemoryHandlesAreReturned) {
   for (auto device : devices) {
     uint32_t count = 0;
-    auto mem_handles = lzt::get_mem_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    count = lzt::get_mem_handle_count(device);
+    if (count > 0) {
+      is_mem_supported = true;
+      LOG_INFO << "Memory handles are available on this device! ";
+      auto mem_handles = lzt::get_mem_handles(device, count);
+      ASSERT_EQ(mem_handles.size(), count);
+      for (auto mem_handle : mem_handles) {
+        EXPECT_NE(nullptr, mem_handle);
+      }
+    } else {
+      LOG_INFO << "No memory handles found for this device! ";
     }
-
-    ASSERT_EQ(mem_handles.size(), count);
-    for (auto mem_handle : mem_handles) {
-      EXPECT_NE(nullptr, mem_handle);
-    }
+  }
+  if (!is_mem_supported) {
+    FAIL() << "No memory handles found on any of the devices! ";
   }
 }
 
@@ -63,15 +80,20 @@ LZT_TEST_F(
     GivenInvalidComponentCountWhenRetrievingSysmanHandlesThenActualComponentCountIsUpdated) {
   for (auto device : devices) {
     uint32_t actual_count = 0;
-    lzt::get_mem_handles(device, actual_count);
-    if (actual_count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    actual_count = lzt::get_mem_handle_count(device);
+    if (actual_count > 0) {
+      is_mem_supported = true;
+      LOG_INFO << "Memory handles are available on this device! ";
+      lzt::get_mem_handles(device, actual_count);
+      uint32_t test_count = actual_count + 1;
+      lzt::get_mem_handles(device, test_count);
+      EXPECT_EQ(test_count, actual_count);
+    } else {
+      LOG_INFO << "No memory handles found for this device! ";
     }
-
-    uint32_t test_count = actual_count + 1;
-    lzt::get_mem_handles(device, test_count);
-    EXPECT_EQ(test_count, actual_count);
+  }
+  if (!is_mem_supported) {
+    FAIL() << "No memory handles found on any of the devices! ";
   }
 }
 
@@ -80,53 +102,61 @@ LZT_TEST_F(
     GivenValidComponentCountWhenCallingApiTwiceThenSimilarMemHandlesReturned) {
   for (auto device : devices) {
     uint32_t count = 0;
-    auto mem_handles_initial = lzt::get_mem_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    count = lzt::get_mem_handle_count(device);
+    if (count > 0) {
+      is_mem_supported = true;
+      LOG_INFO << "Memory handles are available on this device! ";
+      auto mem_handles_initial = lzt::get_mem_handles(device, count);
+      for (auto mem_handle : mem_handles_initial) {
+        EXPECT_NE(nullptr, mem_handle);
+      }
+      count = 0;
+      auto mem_handles_later = lzt::get_mem_handles(device, count);
+      for (auto mem_handle : mem_handles_later) {
+        EXPECT_NE(nullptr, mem_handle);
+      }
+      EXPECT_EQ(mem_handles_initial, mem_handles_later);
+    } else {
+      LOG_INFO << "No memory handles found for this device! ";
     }
-
-    for (auto mem_handle : mem_handles_initial) {
-      EXPECT_NE(nullptr, mem_handle);
-    }
-
-    count = 0;
-    auto mem_handles_later = lzt::get_mem_handles(device, count);
-    for (auto mem_handle : mem_handles_later) {
-      EXPECT_NE(nullptr, mem_handle);
-    }
-    EXPECT_EQ(mem_handles_initial, mem_handles_later);
+  }
+  if (!is_mem_supported) {
+    FAIL() << "No memory handles found on any of the devices! ";
   }
 }
-
 LZT_TEST_F(
     MEMORY_TEST,
     GivenValidMemHandleWhenRetrievingMemPropertiesThenValidPropertiesAreReturned) {
   for (auto device : devices) {
     auto deviceProperties = lzt::get_sysman_device_properties(device);
     uint32_t count = 0;
-    auto mem_handles = lzt::get_mem_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
-    }
-
-    for (auto mem_handle : mem_handles) {
-      ASSERT_NE(nullptr, mem_handle);
-      auto properties = lzt::get_mem_properties(mem_handle);
-      if (properties.onSubdevice) {
-        EXPECT_LT(properties.subdeviceId, deviceProperties.numSubdevices);
+    count = lzt::get_mem_handle_count(device);
+    if (count > 0) {
+      is_mem_supported = true;
+      LOG_INFO << "Memory handles are available on this device! ";
+      auto mem_handles = lzt::get_mem_handles(device, count);
+      for (auto mem_handle : mem_handles) {
+        ASSERT_NE(nullptr, mem_handle);
+        auto properties = lzt::get_mem_properties(mem_handle);
+        if (properties.onSubdevice) {
+          EXPECT_LT(properties.subdeviceId, deviceProperties.numSubdevices);
+        }
+        EXPECT_LT(properties.physicalSize, UINT64_MAX);
+        EXPECT_GE(properties.location, ZES_MEM_LOC_SYSTEM);
+        EXPECT_LE(properties.location, ZES_MEM_LOC_DEVICE);
+        EXPECT_LE(properties.busWidth, INT32_MAX);
+        EXPECT_GE(properties.busWidth, -1);
+        EXPECT_NE(properties.busWidth, 0);
+        EXPECT_LE(properties.numChannels, INT32_MAX);
+        EXPECT_GE(properties.numChannels, -1);
+        EXPECT_NE(properties.numChannels, 0);
       }
-      EXPECT_LT(properties.physicalSize, UINT64_MAX);
-      EXPECT_GE(properties.location, ZES_MEM_LOC_SYSTEM);
-      EXPECT_LE(properties.location, ZES_MEM_LOC_DEVICE);
-      EXPECT_LE(properties.busWidth, INT32_MAX);
-      EXPECT_GE(properties.busWidth, -1);
-      EXPECT_NE(properties.busWidth, 0);
-      EXPECT_LE(properties.numChannels, INT32_MAX);
-      EXPECT_GE(properties.numChannels, -1);
-      EXPECT_NE(properties.numChannels, 0);
+    } else {
+      LOG_INFO << "No memory handles found for this device! ";
     }
+  }
+  if (!is_mem_supported) {
+    FAIL() << "No memory handles found on any of the devices! ";
   }
 }
 
@@ -135,26 +165,33 @@ LZT_TEST_F(
     GivenValidMemHandleWhenRetrievingMemPropertiesThenExpectSamePropertiesReturnedTwice) {
   for (auto device : devices) {
     uint32_t count = 0;
-    auto mem_handles = lzt::get_mem_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
-    }
-
-    for (auto mem_handle : mem_handles) {
-      EXPECT_NE(nullptr, mem_handle);
-      auto properties_initial = lzt::get_mem_properties(mem_handle);
-      auto properties_later = lzt::get_mem_properties(mem_handle);
-      EXPECT_EQ(properties_initial.type, properties_later.type);
-      EXPECT_EQ(properties_initial.onSubdevice, properties_later.onSubdevice);
-      if (properties_initial.onSubdevice && properties_later.onSubdevice) {
-        EXPECT_EQ(properties_initial.subdeviceId, properties_later.subdeviceId);
+    count = lzt::get_mem_handle_count(device);
+    if (count > 0) {
+      is_mem_supported = true;
+      LOG_INFO << "Memory handles are available on this device! ";
+      auto mem_handles = lzt::get_mem_handles(device, count);
+      for (auto mem_handle : mem_handles) {
+        EXPECT_NE(nullptr, mem_handle);
+        auto properties_initial = lzt::get_mem_properties(mem_handle);
+        auto properties_later = lzt::get_mem_properties(mem_handle);
+        EXPECT_EQ(properties_initial.type, properties_later.type);
+        EXPECT_EQ(properties_initial.onSubdevice, properties_later.onSubdevice);
+        if (properties_initial.onSubdevice && properties_later.onSubdevice) {
+          EXPECT_EQ(properties_initial.subdeviceId,
+                    properties_later.subdeviceId);
+        }
+        EXPECT_EQ(properties_initial.physicalSize,
+                  properties_later.physicalSize);
+        EXPECT_EQ(properties_initial.location, properties_later.location);
+        EXPECT_EQ(properties_initial.busWidth, properties_later.busWidth);
+        EXPECT_EQ(properties_initial.numChannels, properties_later.numChannels);
       }
-      EXPECT_EQ(properties_initial.physicalSize, properties_later.physicalSize);
-      EXPECT_EQ(properties_initial.location, properties_later.location);
-      EXPECT_EQ(properties_initial.busWidth, properties_later.busWidth);
-      EXPECT_EQ(properties_initial.numChannels, properties_later.numChannels);
+    } else {
+      LOG_INFO << "No memory handles found for this device! ";
     }
+  }
+  if (!is_mem_supported) {
+    FAIL() << "No memory handles found on any of the devices! ";
   }
 }
 
@@ -163,20 +200,25 @@ LZT_TEST_F(
     GivenValidMemHandleWhenRetrievingMemBandWidthThenValidBandWidthCountersAreReturned) {
   for (auto device : devices) {
     uint32_t count = 0;
-    auto mem_handles = lzt::get_mem_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
+    count = lzt::get_mem_handle_count(device);
+    if (count > 0) {
+      is_mem_supported = true;
+      LOG_INFO << "Memory handles are available on this device! ";
+      auto mem_handles = lzt::get_mem_handles(device, count);
+      for (auto mem_handle : mem_handles) {
+        ASSERT_NE(nullptr, mem_handle);
+        auto bandwidth = lzt::get_mem_bandwidth(mem_handle);
+        EXPECT_LT(bandwidth.readCounter, UINT64_MAX);
+        EXPECT_LT(bandwidth.writeCounter, UINT64_MAX);
+        EXPECT_LT(bandwidth.maxBandwidth, UINT64_MAX);
+        EXPECT_LT(bandwidth.timestamp, UINT64_MAX);
+      }
+    } else {
+      LOG_INFO << "No memory handles found for this device! ";
     }
-
-    for (auto mem_handle : mem_handles) {
-      ASSERT_NE(nullptr, mem_handle);
-      auto bandwidth = lzt::get_mem_bandwidth(mem_handle);
-      EXPECT_LT(bandwidth.readCounter, UINT64_MAX);
-      EXPECT_LT(bandwidth.writeCounter, UINT64_MAX);
-      EXPECT_LT(bandwidth.maxBandwidth, UINT64_MAX);
-      EXPECT_LT(bandwidth.timestamp, UINT64_MAX);
-    }
+  }
+  if (!is_mem_supported) {
+    FAIL() << "No memory handles found on any of the devices! ";
   }
 }
 
@@ -184,23 +226,28 @@ LZT_TEST_F(MEMORY_TEST,
            GivenValidMemHandleWhenRetrievingMemStateThenValidStateIsReturned) {
   for (auto device : devices) {
     uint32_t count = 0;
-    auto mem_handles = lzt::get_mem_handles(device, count);
-    if (count == 0) {
-      FAIL() << "No handles found: "
-             << _ze_result_t(ZE_RESULT_ERROR_UNSUPPORTED_FEATURE);
-    }
-
-    for (auto mem_handle : mem_handles) {
-      ASSERT_NE(nullptr, mem_handle);
-      auto state = lzt::get_mem_state(mem_handle);
-      EXPECT_GE(state.health, ZES_MEM_HEALTH_UNKNOWN);
-      EXPECT_LE(state.health, ZES_MEM_HEALTH_REPLACE);
-      auto properties = lzt::get_mem_properties(mem_handle);
-      if (properties.physicalSize != 0) {
-        EXPECT_LE(state.size, properties.physicalSize);
+    count = lzt::get_mem_handle_count(device);
+    if (count > 0) {
+      is_mem_supported = true;
+      LOG_INFO << "Memory handles are available on this device! ";
+      auto mem_handles = lzt::get_mem_handles(device, count);
+      for (auto mem_handle : mem_handles) {
+        ASSERT_NE(nullptr, mem_handle);
+        auto state = lzt::get_mem_state(mem_handle);
+        EXPECT_GE(state.health, ZES_MEM_HEALTH_UNKNOWN);
+        EXPECT_LE(state.health, ZES_MEM_HEALTH_REPLACE);
+        auto properties = lzt::get_mem_properties(mem_handle);
+        if (properties.physicalSize != 0) {
+          EXPECT_LE(state.size, properties.physicalSize);
+        }
+        EXPECT_LE(state.free, state.size);
       }
-      EXPECT_LE(state.free, state.size);
+    } else {
+      LOG_INFO << "No memory handles found for this device! ";
     }
+  }
+  if (!is_mem_supported) {
+    FAIL() << "No memory handles found on any of the devices! ";
   }
 }
 
@@ -413,37 +460,41 @@ LZT_TEST_F(MEMORY_TEST,
            GivenDeviceWhenRetrievingMemoryPropertiesThenLocationIsAsExpected) {
   for (auto device : devices) {
     uint32_t count = 0;
-    auto mem_handles = lzt::get_mem_handles(device, count);
-
-    if (count == 0) {
-      FAIL() << "No memory handles found on this device!";
-      continue;
-    }
-    ze_device_properties_t deviceProperties = {
-        ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES, nullptr};
+    count = lzt::get_mem_handle_count(device);
+    if (count > 0) {
+      is_mem_supported = true;
+      LOG_INFO << "Memory handles are available on this device! ";
+      auto mem_handles = lzt::get_mem_handles(device, count);
+      ze_device_properties_t deviceProperties = {
+          ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES, nullptr};
 #ifdef USE_ZESINIT
-    auto sysman_device_properties = lzt::get_sysman_device_properties(device);
-    ze_device_handle_t core_device =
-        lzt::get_core_device_by_uuid(sysman_device_properties.core.uuid.id);
-    EXPECT_NE(core_device, nullptr);
-    device = core_device;
+      auto sysman_device_properties = lzt::get_sysman_device_properties(device);
+      ze_device_handle_t core_device =
+          lzt::get_core_device_by_uuid(sysman_device_properties.core.uuid.id);
+      EXPECT_NE(core_device, nullptr);
+      device = core_device;
 #endif // USE_ZESINIT
-    EXPECT_ZE_RESULT_SUCCESS(zeDeviceGetProperties(device, &deviceProperties));
-    bool is_integrated =
-        (deviceProperties.flags & ZE_DEVICE_PROPERTY_FLAG_INTEGRATED);
-
-    for (auto mem_handle : mem_handles) {
-      ASSERT_NE(nullptr, mem_handle);
-
-      auto mem_properties = lzt::get_mem_properties(mem_handle);
-      if (is_integrated) {
-        EXPECT_EQ(mem_properties.location, ZES_MEM_LOC_SYSTEM)
-            << "Integrated device should have system memory location";
-      } else {
-        EXPECT_EQ(mem_properties.location, ZES_MEM_LOC_DEVICE)
-            << "Discrete device should have device memory location";
+      EXPECT_ZE_RESULT_SUCCESS(
+          zeDeviceGetProperties(device, &deviceProperties));
+      bool is_integrated =
+          (deviceProperties.flags & ZE_DEVICE_PROPERTY_FLAG_INTEGRATED);
+      for (auto mem_handle : mem_handles) {
+        ASSERT_NE(nullptr, mem_handle);
+        auto mem_properties = lzt::get_mem_properties(mem_handle);
+        if (is_integrated) {
+          EXPECT_EQ(mem_properties.location, ZES_MEM_LOC_SYSTEM)
+              << "Integrated device should have system memory location";
+        } else {
+          EXPECT_EQ(mem_properties.location, ZES_MEM_LOC_DEVICE)
+              << "Discrete device should have device memory location";
+        }
       }
+    } else {
+      LOG_INFO << "No memory handles found for this device! ";
     }
+  }
+  if (!is_mem_supported) {
+    FAIL() << "No memory handles found on any of the devices! ";
   }
 }
 


### PR DESCRIPTION
Primary JIRA: VLCLJ-2513
Sub-tasks: VLCLJ-2572, VLCLJ-2575, VLCLJ-2564
Update the GTEST_FAIL logic for led, memory and firmware modules. Implemented to check the handles for all the devices and FAIL only if the handle is not found for any device.