### PR TITLE
test: Fix metrics overflow test to use expect instead of assert

### DIFF
--- a/conformance_tests/tools/metrics/src/test_metric_utils.cpp
+++ b/conformance_tests/tools/metrics/src/test_metric_utils.cpp
@@ -347,9 +347,9 @@ void metric_run_ip_sampling_with_validation(
               metricValueSets);
 
       if (enableOverflow) {
-        ASSERT_EQ(ZE_RESULT_WARNING_DROPPED_DATA, result);
+        EXPECT_EQ(ZE_RESULT_WARNING_DROPPED_DATA, result);
       } else {
-        ASSERT_ZE_RESULT_SUCCESS(result);
+        EXPECT_ZE_RESULT_SUCCESS(result);
       }
 
       std::vector<zet_metric_handle_t> metricHandles;


### PR DESCRIPTION
Related-To: NEO-15577

Signed-off-by: shubham kumar <shubham.kumar@intel.com>