### PR TITLE
Fix/type mismatch warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,11 +348,11 @@ else()
     set(CMAKE_NEWLINE "\n")
 endif()
 
-if (MSVC)
-    add_compile_options(/W4)
-else()
-    add_compile_options(-Wsign-compare -Wnarrowing)
-endif()
+# if (MSVC)
+#     add_compile_options(/W4)
+# else()
+#     add_compile_options(-Wsign-compare -Wnarrowing)
+# endif()
 
 option(ENABLE_ZESYSMAN
   "Enables build of zesysman"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,6 +348,11 @@ else()
     set(CMAKE_NEWLINE "\n")
 endif()
 
+if (MSVC)
+    add_compile_options(/W4)
+else()
+    add_compile_options(-Wsign-compare -Wnarrowing)
+endif()
 
 option(ENABLE_ZESYSMAN
   "Enables build of zesysman"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,11 +348,11 @@ else()
     set(CMAKE_NEWLINE "\n")
 endif()
 
-# if (MSVC)
-#     add_compile_options(/W4)
-# else()
-#     add_compile_options(-Wsign-compare -Wnarrowing)
-# endif()
+if (MSVC)
+    add_compile_options(/W4)
+else()
+    add_compile_options(-Wsign-compare -Wnarrowing)
+endif()
 
 option(ENABLE_ZESYSMAN
   "Enables build of zesysman"

--- a/conformance_tests/core/test_barrier/src/test_barrier.cpp
+++ b/conformance_tests/core/test_barrier/src/test_barrier.cpp
@@ -118,7 +118,7 @@ void RunAppendingBarrierWithSignalEventAndWaitEvents(bool isImmediate) {
   for (auto &ev : events) {
     lzt::signal_event_from_host(ev);
   }
-  for (int i = 0; i < events.size(); i++) {
+  for (size_t i = 0U; i < events.size(); i++) {
     ASSERT_EQ(events[i], events_initial[i]);
   }
   ep.destroy_events(events);
@@ -233,7 +233,7 @@ void RunAppendingMemoryRangesBarrierWaitEvents(bool isImmediate) {
   auto wait_events_initial = waiting_events;
   AppendMemoryRangesBarrierTest(context, device, bundle.list, nullptr,
                                 waiting_events);
-  for (int i = 0; i < waiting_events.size(); i++) {
+  for (size_t i = 0U; i < waiting_events.size(); i++) {
     ASSERT_EQ(waiting_events[i], wait_events_initial[i]);
   }
   ep.destroy_events(waiting_events);

--- a/conformance_tests/core/test_cmdlist/src/test_cmdlist.cpp
+++ b/conformance_tests/core/test_cmdlist/src/test_cmdlist.cpp
@@ -343,17 +343,17 @@ LZT_TEST(zeCommandListReuseTests,
   lzt::append_memory_copy(cmdlist_mem_zero, host_buffer, device_buffer, size);
   lzt::close_command_list(cmdlist_mem_zero);
 
-  const int num_execute = 5;
-  for (int i = 0; i < num_execute; i++) {
+  const uint32_t num_execute = 5;
+  for (uint32_t i = 0U; i < num_execute; i++) {
     lzt::execute_command_lists(cmdq, 1, &cmdlist_mem_zero, nullptr);
     lzt::synchronize(cmdq, UINT64_MAX);
-    for (int j = 0; j < size; j++)
+    for (size_t j = 0U; j < size; j++)
       ASSERT_EQ(static_cast<uint8_t *>(host_buffer)[j], 0x0)
           << "Memory Set did not match.";
 
     lzt::execute_command_lists(cmdq, 1, &cmdlist_mem_set, nullptr);
     lzt::synchronize(cmdq, UINT64_MAX);
-    for (int j = 0; j < size; j++)
+    for (size_t j = 0U; j < size; j++)
       ASSERT_EQ(static_cast<uint8_t *>(host_buffer)[j], 0x1)
           << "Memory Set did not match.";
   }
@@ -1068,7 +1068,7 @@ RunAppendLaunchKernelEventLoop(cmdListVec cmdlist, cmdQueueVec cmdqueue,
   }
 
   constexpr size_t size = 16;
-  for (int i = 1; i <= cmdlist.size(); i++) {
+  for (size_t i = 1; i <= cmdlist.size(); i++) {
     LOG_INFO << "Testing " << i << " command list(s)";
     func(cmdlist, cmdqueue, event, i, size);
   }

--- a/conformance_tests/core/test_cmdlist/src/test_cmdlist_immediate.cpp
+++ b/conformance_tests/core/test_cmdlist/src/test_cmdlist_immediate.cpp
@@ -422,7 +422,7 @@ LZT_TEST_F(
     GTEST_SKIP() << "Extension " << ZE_EVENT_POOL_COUNTER_BASED_EXP_NAME
                  << " not supported";
   }
-  for (int i = 1; i <= cmdlist.size(); i++) {
+  for (size_t i = 1; i <= cmdlist.size(); i++) {
     LOG_INFO << "Running " << i << " command list(s)";
     RunAppendLaunchKernelEvent(cmdlist, event0, i, false);
   }
@@ -438,7 +438,7 @@ LZT_TEST_F(
     GTEST_SKIP() << "Extension " << ZE_EVENT_POOL_COUNTER_BASED_EXP_NAME
                  << " not supported";
   }
-  for (int i = 1; i <= cmdlist.size(); i++) {
+  for (size_t i = 1; i <= cmdlist.size(); i++) {
     LOG_INFO << "Running " << i << " command list(s)";
     RunAppendLaunchKernelEvent(cmdlist, event0, i, true);
   }

--- a/conformance_tests/core/test_cmdlist/src/test_cmdlist_mixed.cpp
+++ b/conformance_tests/core/test_cmdlist/src/test_cmdlist_mixed.cpp
@@ -166,7 +166,7 @@ LZT_TEST_P(
   lzt::set_group_size(kernel, 8, 1, 1);
   const ze_group_count_t dispatch = {vec_sz / 8, 1, 1};
 
-  for (int i = 0; i < cls_compute.size(); i++) {
+  for (size_t i = 0U; i < cls_compute.size(); i++) {
     const auto cl = cls_compute[i];
     void *h_vec = host_vecs_compute[i];
     void *d_vec = device_vecs_compute[i];
@@ -188,15 +188,15 @@ LZT_TEST_P(
   }
 
   // Submit compute engine CMD lists, ASYNC execution
-  for (int i = 0; i < cls_compute.size(); i++) {
+  for (size_t i = 0U; i < cls_compute.size(); i++) {
     lzt::execute_command_lists(cqs_compute[i], 1, &cls_compute[i], nullptr);
   }
 
   // Submit tasks to copy engine immediate CMD lists
   const int log_blk_len = 8;
   const int blk_sz = (1u << log_blk_len);
-  for (int i = 0; i < (vec_sz >> log_blk_len); i++) {
-    for (int j = 0; j < cls_copy_imm.size(); j++) {
+  for (size_t i = 0U; i < (vec_sz >> log_blk_len); i++) {
+    for (size_t j = 0U; j < cls_copy_imm.size(); j++) {
       const auto cl = cls_copy_imm[j];
       const auto device_ptr =
           reinterpret_cast<uint8_t *>(device_vecs_copy[j]) + i * blk_sz;
@@ -207,7 +207,7 @@ LZT_TEST_P(
       lzt::append_memory_copy(cl, host_ptr, device_ptr, blk_sz, events_copy[j],
                               1, &events_fill[j]);
     }
-    for (int j = 0; j < cls_copy_imm.size(); j++) {
+    for (size_t j = 0U; j < cls_copy_imm.size(); j++) {
       if (use_events_sync) {
         EXPECT_ZE_RESULT_SUCCESS(
             zeEventHostSynchronize(events_copy[j], UINT64_MAX));
@@ -221,14 +221,14 @@ LZT_TEST_P(
   }
 
   // Sync with compute engine queues
-  for (int i = 0; i < cls_compute.size(); i++) {
+  for (size_t i = 0U; i < cls_compute.size(); i++) {
     lzt::synchronize(cqs_compute[i], UINT64_MAX);
   }
 
   // Verify compute engine results
-  for (uint8_t i = 0; i < cls_compute.size(); i++) {
+  for (size_t i = 0U; i < cls_compute.size(); i++) {
     const uint8_t *vec = reinterpret_cast<uint8_t *>(host_vecs_compute[i]);
-    for (size_t j = 0; j < vec_sz; j++) {
+    for (size_t j = 0U; j < vec_sz; j++) {
       if (vec[j] != i + 2) {
         EXPECT_TRUE(false);
         break;
@@ -237,9 +237,9 @@ LZT_TEST_P(
   }
 
   // Verify copy engine results
-  for (uint8_t i = 0; i < cls_copy_imm.size(); i++) {
+  for (size_t i = 0U; i < cls_copy_imm.size(); i++) {
     const uint8_t *vec = reinterpret_cast<uint8_t *>(host_vecs_copy[i]);
-    for (size_t j = 0; j < vec_sz; j++) {
+    for (size_t j = 0U; j < vec_sz; j++) {
       if (vec[j] != i + 42) {
         EXPECT_TRUE(false);
         break;
@@ -248,14 +248,14 @@ LZT_TEST_P(
   }
 
   // Cleanup
-  for (int i = 0; i < cls_compute.size(); i++) {
+  for (size_t i = 0U; i < cls_compute.size(); i++) {
     lzt::free_memory(host_vecs_compute[i]);
     lzt::free_memory(device_vecs_compute[i]);
     lzt::destroy_command_list(cls_compute[i]);
     lzt::destroy_command_queue(cqs_compute[i]);
   }
 
-  for (int i = 0; i < cls_copy_imm.size(); i++) {
+  for (size_t i = 0U; i < cls_copy_imm.size(); i++) {
     lzt::free_memory(host_vecs_copy[i]);
     lzt::free_memory(device_vecs_copy[i]);
     lzt::destroy_command_list(cls_copy_imm[i]);
@@ -335,9 +335,9 @@ LZT_TEST_P(
   // Fill copy engine CMD lists with tasks
   const int log_blk_len = 1;
   const int blk_sz = (1u << log_blk_len);
-  for (int j = 0; j < cls_copy.size(); j++) {
+  for (size_t j = 0U; j < cls_copy.size(); j++) {
     const auto cl = cls_copy[j];
-    for (int i = 0; i < (vec_sz >> log_blk_len); i++) {
+    for (size_t i = 0U; i < (vec_sz >> log_blk_len); i++) {
       const auto device_ptr =
           reinterpret_cast<uint8_t *>(device_vecs_copy[j]) + i * blk_sz;
       const auto host_ptr =
@@ -352,12 +352,12 @@ LZT_TEST_P(
   }
 
   // Submit copy engine CMD lists, ASYNC execution
-  for (int i = 0; i < cls_copy.size(); i++) {
+  for (size_t i = 0U; i < cls_copy.size(); i++) {
     lzt::execute_command_lists(cqs_copy[i], 1, &cls_copy[i], nullptr);
   }
 
   // Submit tasks to compute engine immediate CMD lists
-  for (int i = 0; i < cls_compute_imm.size(); i++) {
+  for (size_t i = 0U; i < cls_compute_imm.size(); i++) {
     lzt::append_memory_fill(cls_compute_imm[i], device_vecs_compute[i],
                             &patterns_compute[i], 1, vec_sz, nullptr);
     lzt::append_barrier(cls_compute_imm[i]);
@@ -366,18 +366,18 @@ LZT_TEST_P(
   lzt::set_group_size(kernel, 8, 1, 1);
   const ze_group_count_t dispatch = {vec_sz / 8, 1, 1};
 
-  for (int i = 0; i < cls_compute_imm.size(); i++) {
+  for (size_t i = 0U; i < cls_compute_imm.size(); i++) {
     lzt::set_argument_value(kernel, 0, sizeof(void *), &device_vecs_compute[i]);
     lzt::append_launch_function(cls_compute_imm[i], kernel, &dispatch, nullptr,
                                 0, nullptr);
     lzt::append_barrier(cls_compute_imm[i]);
   }
-  for (int i = 0; i < cls_compute_imm.size(); i++) {
+  for (size_t i = 0U; i < cls_compute_imm.size(); i++) {
     lzt::append_memory_copy(cls_compute_imm[i], host_vecs_compute[i],
                             device_vecs_compute[i], vec_sz, events[i]);
     lzt::append_barrier(cls_compute_imm[i]);
   }
-  for (int i = 0; i < cls_compute_imm.size(); i++) {
+  for (size_t i = 0U; i < cls_compute_imm.size(); i++) {
     if (use_events_sync) {
       lzt::event_host_synchronize(events[i], UINT64_MAX);
     } else {
@@ -387,14 +387,14 @@ LZT_TEST_P(
   }
 
   // Sync with copy engine queues
-  for (int i = 0; i < cls_copy.size(); i++) {
+  for (size_t i = 0U; i < cls_copy.size(); i++) {
     lzt::synchronize(cqs_copy[i], UINT64_MAX);
   }
 
   // Verify copy engine results
-  for (uint8_t i = 0; i < cls_copy.size(); i++) {
+  for (size_t i = 0U; i < cls_copy.size(); i++) {
     const uint8_t *vec = reinterpret_cast<uint8_t *>(host_vecs_copy[i]);
-    for (size_t j = 0; j < vec_sz; j++) {
+    for (size_t j = 0U; j < vec_sz; j++) {
       if (vec[j] != i + 42) {
         EXPECT_TRUE(false);
         break;
@@ -403,9 +403,9 @@ LZT_TEST_P(
   }
 
   // Verify compute engine results
-  for (uint8_t i = 0; i < cls_compute_imm.size(); i++) {
+  for (size_t i = 0U; i < cls_compute_imm.size(); i++) {
     const uint8_t *vec = reinterpret_cast<uint8_t *>(host_vecs_compute[i]);
-    for (size_t j = 0; j < vec_sz; j++) {
+    for (size_t j = 0U; j < vec_sz; j++) {
       if (vec[j] != i + 1) {
         EXPECT_TRUE(false);
         break;
@@ -414,13 +414,13 @@ LZT_TEST_P(
   }
 
   // Cleanup
-  for (int i = 0; i < cls_compute_imm.size(); i++) {
+  for (size_t i = 0U; i < cls_compute_imm.size(); i++) {
     lzt::free_memory(host_vecs_compute[i]);
     lzt::free_memory(device_vecs_compute[i]);
     lzt::destroy_command_list(cls_compute_imm[i]);
     lzt::destroy_event(events[i]);
   }
-  for (int i = 0; i < cls_copy.size(); i++) {
+  for (size_t i = 0U; i < cls_copy.size(); i++) {
     lzt::free_memory(host_vecs_copy[i]);
     lzt::free_memory(device_vecs_copy[i]);
     lzt::destroy_command_list(cls_copy[i]);
@@ -495,7 +495,7 @@ LZT_TEST_P(
   const ze_group_count_t dispatch = {vec_sz / 8, 1, 1};
 
   // Fill regular CMD lists
-  for (int i = 0; i < cls.size(); i++) {
+  for (size_t i = 0U; i < cls.size(); i++) {
     const auto cl = cls[i];
     void *h_vec = host_vecs[i];
     void *d_vec = device_vecs[i];
@@ -516,28 +516,28 @@ LZT_TEST_P(
   }
 
   // Submit regular CMD lists, ASYNC execution
-  for (int i = 0; i < cls.size(); i++) {
+  for (size_t i = 0U; i < cls.size(); i++) {
     lzt::execute_command_lists(cqs[i], 1, &cls[i], nullptr);
   }
 
   // Submit tasks to the immediate CMD lists
-  for (int i = 0; i < cls_imm.size(); i++) {
+  for (size_t i = 0U; i < cls_imm.size(); i++) {
     lzt::append_memory_fill(cls_imm[i], device_vecs_imm[i], &patterns_imm[i], 1,
                             vec_sz, nullptr);
     lzt::append_barrier(cls_imm[i]);
   }
-  for (int i = 0; i < cls_imm.size(); i++) {
+  for (size_t i = 0U; i < cls_imm.size(); i++) {
     lzt::set_argument_value(kernel, 0, sizeof(void *), &device_vecs_imm[i]);
     lzt::append_launch_function(cls_imm[i], kernel, &dispatch, nullptr, 0,
                                 nullptr);
     lzt::append_barrier(cls_imm[i]);
   }
-  for (int i = 0; i < cls_imm.size(); i++) {
+  for (size_t i = 0U; i < cls_imm.size(); i++) {
     lzt::append_memory_copy(cls_imm[i], host_vecs_imm[i], device_vecs_imm[i],
                             vec_sz, events[i]);
     lzt::append_barrier(cls_imm[i]);
   }
-  for (int i = 0; i < cls_imm.size(); i++) {
+  for (size_t i = 0U; i < cls_imm.size(); i++) {
     if (use_events_sync) {
       lzt::event_host_synchronize(events[i], UINT64_MAX);
     } else {
@@ -547,14 +547,14 @@ LZT_TEST_P(
   }
 
   // Sync with regular CMD lists
-  for (int i = 0; i < cls.size(); i++) {
+  for (size_t i = 0U; i < cls.size(); i++) {
     lzt::synchronize(cqs[i], UINT64_MAX);
   }
 
   // Verify regular CMD lists' results
-  for (uint8_t i = 0; i < cls.size(); i++) {
+  for (size_t i = 0U; i < cls.size(); i++) {
     const uint8_t *vec = reinterpret_cast<uint8_t *>(host_vecs[i]);
-    for (size_t j = 0; j < vec_sz; j++) {
+    for (size_t j = 0U; j < vec_sz; j++) {
       if (vec[j] != i + 2) {
         EXPECT_TRUE(false);
         break;
@@ -563,9 +563,9 @@ LZT_TEST_P(
   }
 
   // Verify immediate CMD lists' results
-  for (uint8_t i = 0; i < cls_imm.size(); i++) {
+  for (size_t i = 0U; i < cls_imm.size(); i++) {
     const uint8_t *vec = reinterpret_cast<uint8_t *>(host_vecs_imm[i]);
-    for (size_t j = 0; j < vec_sz; j++) {
+    for (size_t j = 0U; j < vec_sz; j++) {
       if (vec[j] != i + 43) {
         EXPECT_TRUE(false);
         break;
@@ -574,7 +574,7 @@ LZT_TEST_P(
   }
 
   // Cleanup
-  for (int i = 0; i < cls.size(); i++) {
+  for (size_t i = 0U; i < cls.size(); i++) {
     lzt::free_memory(host_vecs[i]);
     lzt::free_memory(host_vecs_imm[i]);
     lzt::free_memory(device_vecs[i]);
@@ -658,9 +658,9 @@ LZT_TEST_P(
   const int blk_sz = (1u << log_blk_len);
 
   // Fill regular CMD lists
-  for (int j = 0; j < cls.size(); j++) {
+  for (size_t j = 0U; j < cls.size(); j++) {
     const auto cl = cls[j];
-    for (int i = 0; i < (vec_sz >> log_blk_len); i++) {
+    for (size_t i = 0U; i < (vec_sz >> log_blk_len); i++) {
       const auto device_ptr =
           reinterpret_cast<uint8_t *>(device_vecs[j]) + i * blk_sz;
       const auto host_ptr =
@@ -674,13 +674,13 @@ LZT_TEST_P(
   }
 
   // Submit regular CMD lists, ASYNC execution
-  for (int i = 0; i < cls.size(); i++) {
+  for (size_t i = 0U; i < cls.size(); i++) {
     lzt::execute_command_lists(cqs[i], 1, &cls[i], nullptr);
   }
 
   // Submit tasks to immediate CMD lists
-  for (int i = 0; i < (vec_sz >> log_blk_len); i++) {
-    for (int j = 0; j < cls_imm.size(); j++) {
+  for (size_t i = 0U; i < (vec_sz >> log_blk_len); i++) {
+    for (size_t j = 0U; j < cls_imm.size(); j++) {
       const auto cl = cls_imm[j];
       const auto device_ptr =
           reinterpret_cast<uint8_t *>(device_vecs_imm[j]) + i * blk_sz;
@@ -691,7 +691,7 @@ LZT_TEST_P(
       lzt::append_memory_copy(cl, host_ptr, device_ptr, blk_sz, events_copy[j],
                               1, &events_fill[j]);
     }
-    for (int j = 0; j < cls_imm.size(); j++) {
+    for (size_t j = 0U; j < cls_imm.size(); j++) {
       if (use_events_sync) {
         EXPECT_ZE_RESULT_SUCCESS(
             zeEventHostSynchronize(events_copy[j], UINT64_MAX));
@@ -706,14 +706,14 @@ LZT_TEST_P(
   }
 
   // Sync with regular CMD lists' queues
-  for (int i = 0; i < cls.size(); i++) {
+  for (size_t i = 0U; i < cls.size(); i++) {
     lzt::synchronize(cqs[i], UINT64_MAX);
   }
 
   // Verify regular CMD lists' results
-  for (uint8_t i = 0; i < cls.size(); i++) {
+  for (size_t i = 0U; i < cls.size(); i++) {
     const uint8_t *vec = reinterpret_cast<uint8_t *>(host_vecs[i]);
-    for (size_t j = 0; j < vec_sz; j++) {
+    for (size_t j = 0U; j < vec_sz; j++) {
       if (vec[j] != i + 1) {
         EXPECT_TRUE(false);
         break;
@@ -722,9 +722,9 @@ LZT_TEST_P(
   }
 
   // Verify immediate CMD lists' results
-  for (uint8_t i = 0; i < cls_imm.size(); i++) {
+  for (size_t i = 0U; i < cls_imm.size(); i++) {
     const uint8_t *vec = reinterpret_cast<uint8_t *>(host_vecs_imm[i]);
-    for (size_t j = 0; j < vec_sz; j++) {
+    for (size_t j = 0U; j < vec_sz; j++) {
       if (vec[j] != i + 42) {
         EXPECT_TRUE(false);
         break;
@@ -733,7 +733,7 @@ LZT_TEST_P(
   }
 
   // Cleanup
-  for (int i = 0; i < cls.size(); i++) {
+  for (size_t i = 0U; i < cls.size(); i++) {
     lzt::free_memory(host_vecs[i]);
     lzt::free_memory(host_vecs_imm[i]);
     lzt::free_memory(device_vecs[i]);
@@ -997,7 +997,7 @@ protected:
 
   uint8_t *vec_hst;
   uint8_t *vec_dev;
-  const int n_iters = 8;
+  const uint32_t n_iters = 8;
 };
 
 LZT_TEST_P(
@@ -1070,7 +1070,7 @@ LZT_TEST_P(
   const ze_group_count_t dispatch = {vec_sz / 8, 1, 1};
   lzt::set_argument_value(kernel, 0, sizeof(void *), &vec_dev);
 
-  for (int i = 0; i < n_iters; i++) {
+  for (uint32_t i = 0U; i < n_iters; i++) {
     // Copy to device and signal kernel launch
     lzt::append_memory_copy(cl_h2d_imm, vec_dev, vec_hst, vec_sz, nullptr, 1,
                             &ev_h2d);
@@ -1113,7 +1113,7 @@ LZT_TEST_P(
   lzt::query_event(ev_compute, ZE_RESULT_NOT_READY);
   lzt::query_event(ev_d2h, ZE_RESULT_NOT_READY);
 
-  for (int i = 0; i < vec_sz; i++) {
+  for (size_t i = 0U; i < vec_sz; i++) {
     if (vec_hst[i] != n_iters) {
       EXPECT_TRUE(false);
       break;
@@ -1201,7 +1201,7 @@ LZT_TEST_P(
   const ze_group_count_t dispatch = {vec_sz / 8, 1, 1};
   lzt::set_argument_value(kernel, 0, sizeof(void *), &vec_dev);
 
-  for (int i = 0; i < n_iters; i++) {
+  for (uint32_t i = 0U; i < n_iters; i++) {
     // Copy to device and signal kernel launch
     lzt::append_memory_copy(cl_h2d, vec_dev, vec_hst, vec_sz, nullptr, 1,
                             &ev_h2d);
@@ -1244,7 +1244,7 @@ LZT_TEST_P(
   lzt::query_event(ev_compute, ZE_RESULT_NOT_READY);
   lzt::query_event(ev_d2h, ZE_RESULT_NOT_READY);
 
-  for (int i = 0; i < vec_sz; i++) {
+  for (size_t i = 0U; i < vec_sz; i++) {
     if (vec_hst[i] != n_iters) {
       EXPECT_TRUE(false);
       break;
@@ -1338,7 +1338,7 @@ LZT_TEST_P(
   const ze_group_count_t dispatch = {vec_sz / 8, 1, 1};
   lzt::set_argument_value(kernel, 0, sizeof(void *), &vec_dev);
 
-  for (int i = 0; i < n_iters; i++) {
+  for (uint32_t i = 0U; i < n_iters; i++) {
     // Copy to device and signal kernel launch
     lzt::append_memory_copy(cl_h2d_imm, vec_dev, vec_hst, vec_sz, nullptr, 1,
                             &ev_h2d);
@@ -1380,7 +1380,7 @@ LZT_TEST_P(
   lzt::query_event(ev_compute, ZE_RESULT_NOT_READY);
   lzt::query_event(ev_d2h, ZE_RESULT_NOT_READY);
 
-  for (int i = 0; i < vec_sz; i++) {
+  for (size_t i = 0U; i < vec_sz; i++) {
     if (vec_hst[i] != n_iters) {
       EXPECT_TRUE(false);
       break;
@@ -1455,9 +1455,9 @@ LZT_TEST_P(
   ev_desc.wait = ZE_EVENT_SCOPE_FLAG_HOST;
   auto ev_copy = lzt::create_event(event_pool, ev_desc);
 
-  const int blk_sz = vec_sz / n_iters;
+  const uint32_t blk_sz = static_cast<uint32_t>(vec_sz / n_iters);
 
-  for (int i = 0; i < n_iters; i++) {
+  for (uint32_t i = 0U; i < n_iters; i++) {
     // Fill the device buffer block
     lzt::append_memory_fill(cl_fill, vec_dev + i * blk_sz, &n_iters, 1, blk_sz,
                             nullptr, 1, &ev_fill);
@@ -1492,7 +1492,7 @@ LZT_TEST_P(
   lzt::query_event(ev_fill, ZE_RESULT_SUCCESS);
   lzt::query_event(ev_copy, ZE_RESULT_NOT_READY);
 
-  for (int i = 0; i < blk_sz * n_iters; i++) {
+  for (uint32_t i = 0U; i < blk_sz * n_iters; i++) {
     if (vec_hst[i] != n_iters) {
       EXPECT_TRUE(false);
       break;
@@ -1693,7 +1693,7 @@ LZT_TEST_F(
     GTEST_SKIP() << "Extension " << ZE_EVENT_POOL_COUNTER_BASED_EXP_NAME
                  << " not supported";
   }
-  for (int i = 1; i <= cmdlist.size(); i++) {
+  for (size_t i = 1; i <= cmdlist.size(); i++) {
     LOG_INFO << "Testing " << i << " command list(s)";
     RunAppendLaunchKernelEvent(cmdlist, cmdqueue, event0, i, false);
   }
@@ -1708,7 +1708,7 @@ LZT_TEST_F(
     GTEST_SKIP() << "Extension " << ZE_EVENT_POOL_COUNTER_BASED_EXP_NAME
                  << " not supported";
   }
-  for (int i = 1; i <= cmdlist.size(); i++) {
+  for (size_t i = 1; i <= cmdlist.size(); i++) {
     LOG_INFO << "Testing " << i << " command list(s)";
     RunAppendLaunchKernelEvent(cmdlist, cmdqueue, event0, i, true);
   }

--- a/conformance_tests/core/test_cmdqueue/src/test_cmdqueue.cpp
+++ b/conformance_tests/core/test_cmdqueue/src/test_cmdqueue.cpp
@@ -59,7 +59,7 @@ LZT_TEST_P(zeCommandQueueCreateTests,
 
   auto cmd_q_group_properties = lzt::get_command_queue_group_properties(device);
 
-  for (int i = 0; i < cmd_q_group_properties.size(); i++) {
+  for (size_t i = 0U; i < cmd_q_group_properties.size(); i++) {
     descriptor.ordinal = i;
     print_cmdqueue_descriptor(descriptor);
 
@@ -221,7 +221,7 @@ LZT_TEST_P(
   EXPECT_ZE_RESULT_SUCCESS(
       zeCommandQueueExecuteCommandLists(command_queue, params.num_command_lists,
                                         list_of_command_lists.data(), nullptr));
-  for (int i = 0; i < list_of_command_lists.size(); i++) {
+  for (size_t i = 0U; i < list_of_command_lists.size(); i++) {
     ASSERT_EQ(list_of_command_lists[i], command_lists_initial[i]);
   }
   ze_result_t sync_status = ZE_RESULT_NOT_READY;
@@ -530,8 +530,8 @@ LZT_TEST_F(
 LZT_TEST(
     CommandQueuePriorityTest,
     GivenConcurrentLogicalCommandQueuesWhenStartSynchronizedThenHighPriorityCompletesFirst) {
-  const int buff_size_high = 1 << 10;
-  const int buff_size_low = 1 << 20;
+  const uint32_t buff_size_high = 1 << 10;
+  const uint32_t buff_size_low = 1 << 20;
   const uint8_t value_high = 0x55;
   const uint8_t value_low = 0x22;
   std::vector<ze_device_handle_t> devices;
@@ -586,7 +586,7 @@ LZT_TEST(
       std::vector<ze_command_list_handle_t> cmdlist_compute_lows;
 
       std::vector<void *> buffer_compute_lows;
-      for (int i = 0; i < num_low_priority_compute_queues; i++) {
+      for (uint32_t i = 0U; i < num_low_priority_compute_queues; i++) {
         auto cmdqueue_compute_low = lzt::create_command_queue(
             device, static_cast<ze_command_queue_flag_t>(0),
             ZE_COMMAND_QUEUE_MODE_ASYNCHRONOUS,
@@ -612,7 +612,7 @@ LZT_TEST(
                              &value_high, buff_size_high, event_compute_high);
       lzt::close_command_list(cmdlist_compute_high);
 
-      for (int i = 0; i < num_low_priority_compute_queues; i++) {
+      for (uint32_t i = 0U; i < num_low_priority_compute_queues; i++) {
         auto cmdlist_compute_low = cmdlist_compute_lows[i];
         auto buffer_compute_low = buffer_compute_lows[i];
         auto event_compute_low = event_compute_lows[i];
@@ -622,7 +622,7 @@ LZT_TEST(
         lzt::close_command_list(cmdlist_compute_low);
       }
 
-      for (int i = 0; i < num_low_priority_compute_queues; i++) {
+      for (uint32_t i = 0U; i < num_low_priority_compute_queues; i++) {
         auto cmdqueue_compute_low = cmdqueue_compute_lows[i];
         auto cmdlist_compute_low = cmdlist_compute_lows[i];
 
@@ -633,21 +633,21 @@ LZT_TEST(
                                  &cmdlist_compute_high, nullptr);
       lzt::signal_event_from_host(event_sync);
 
-      for (int i = 0; i < num_low_priority_compute_queues; i++) {
+      for (uint32_t i = 0U; i < num_low_priority_compute_queues; i++) {
         auto cmdqueue_compute_low = cmdqueue_compute_lows[i];
         lzt::synchronize(cmdqueue_compute_low, UINT64_MAX);
       }
       lzt::synchronize(cmdqueue_compute_high, UINT64_MAX);
 
       uint8_t *uchar_compute_high = static_cast<uint8_t *>(buffer_compute_high);
-      for (size_t i = 0; i < buff_size_high; i++) {
+      for (uint32_t i = 0U; i < buff_size_high; i++) {
         EXPECT_EQ(value_high, uchar_compute_high[i]);
       }
 
-      for (int i = 0; i < num_low_priority_compute_queues; i++) {
+      for (uint32_t i = 0U; i < num_low_priority_compute_queues; i++) {
         auto buffer_compute_low = buffer_compute_lows[i];
         uint8_t *uchar_compute_low = static_cast<uint8_t *>(buffer_compute_low);
-        for (size_t i = 0; i < buff_size_low; i++) {
+        for (uint32_t i = 0U; i < buff_size_low; i++) {
           EXPECT_EQ(value_low, uchar_compute_low[i]);
         }
       }
@@ -659,7 +659,7 @@ LZT_TEST(
 
       uint32_t
           number_of_low_priority_queues_finished_after_high_priority_queue = 0;
-      for (int i = 0; i < num_low_priority_compute_queues; i++) {
+      for (uint32_t i = 0U; i < num_low_priority_compute_queues; i++) {
         auto event_compute_low = event_compute_lows[i];
         EXPECT_ZE_RESULT_SUCCESS(zeEventQueryStatus(event_compute_low));
         ze_kernel_timestamp_result_t event_compute_low_timestamp =
@@ -686,7 +686,7 @@ LZT_TEST(
           << number_of_low_priority_queues_finished_after_high_priority_queue;
       /*cleanup*/
 
-      for (int i = 0; i < num_low_priority_compute_queues; i++) {
+      for (uint32_t i = 0U; i < num_low_priority_compute_queues; i++) {
         auto cmdqueue_compute_low = cmdqueue_compute_lows[i];
         lzt::destroy_command_queue(cmdqueue_compute_low);
         auto cmdlist_compute_low = cmdlist_compute_lows[i];
@@ -701,7 +701,7 @@ LZT_TEST(
 
       lzt::destroy_event(event_compute_high);
 
-      for (int i = 0; i < num_low_priority_compute_queues; i++) {
+      for (uint32_t i = 0U; i < num_low_priority_compute_queues; i++) {
         auto event_compute_low = event_compute_lows[i];
         lzt::destroy_event(event_compute_low);
       }
@@ -731,7 +731,7 @@ public:
     auto cmdq_group_properties =
         lzt::get_command_queue_group_properties(device);
     int copy_ordinal = -1;
-    for (int i = 0; i < cmdq_group_properties.size(); i++) {
+    for (size_t i = 0U; i < cmdq_group_properties.size(); i++) {
       if ((cmdq_group_properties[i].flags &
            ZE_COMMAND_QUEUE_GROUP_PROPERTY_FLAG_COPY) &&
           !(cmdq_group_properties[i].flags &
@@ -946,7 +946,7 @@ LZT_TEST(ConcurrentCommandQueueExecutionTests,
   auto device = lzt::get_default_device(driver);
   auto cmdq_groups = lzt::get_command_queue_group_properties(device);
 
-  std::vector<int> num_queues_per_group;
+  std::vector<uint32_t> num_queues_per_group;
   for (auto properties : cmdq_groups) {
     num_queues_per_group.push_back(properties.numQueues);
   }

--- a/conformance_tests/core/test_copy/src/test_copy.cpp
+++ b/conformance_tests/core/test_copy/src/test_copy.cpp
@@ -151,7 +151,7 @@ void zeCommandListAppendMemoryFillTests::RunMaxMemoryFillTest(
   auto device_properties = lzt::get_device_properties(device);
   auto max_alloc_memsize = device_properties.maxMemAllocSize;
 
-  for (int i = 0; i < cmd_q_group_properties.size(); i++) {
+  for (size_t i = 0U; i < cmd_q_group_properties.size(); i++) {
     auto bundle = lzt::create_command_bundle(lzt::get_default_context(), device,
                                              0, i, is_immediate);
     size_t size = cmd_q_group_properties[i].maxMemoryFillPatternSize;
@@ -606,7 +606,7 @@ LZT_TEST_P(
       lzt::close_command_list(cmd_bundle.list);
       lzt::execute_and_sync_command_bundle(cmd_bundle, UINT64_MAX);
 
-      for (int i = 0; i < size; i++) {
+      for (size_t i = 0U; i < size; i++) {
         ASSERT_EQ(static_cast<uint8_t *>(host_memory)[i], pattern)
             << "Memory Fill did not match on sub-device";
       }
@@ -639,7 +639,7 @@ protected:
 
 void zeCommandListAppendMemoryFillPatternVerificationTests::
     RunGivenPatternSizeWhenExecutingAMemoryFillTest(bool is_shared_system) {
-  const int pattern_size = std::get<0>(GetParam());
+  const size_t pattern_size = std::get<0>(GetParam());
   const bool is_immediate = std::get<1>(GetParam());
   auto cmd_bundle = lzt::create_command_bundle(is_immediate);
   const size_t total_size = (pattern_size * 10) + 5;
@@ -647,7 +647,7 @@ void zeCommandListAppendMemoryFillPatternVerificationTests::
   auto target_memory = lzt::allocate_host_memory_with_allocator_selector(
       total_size, is_shared_system);
 
-  for (uint32_t i = 0; i < pattern_size; i++) {
+  for (size_t i = 0U; i < pattern_size; i++) {
     pattern.get()[i] = i;
   }
 
@@ -657,7 +657,7 @@ void zeCommandListAppendMemoryFillPatternVerificationTests::
   close_command_list(cmd_bundle.list);
   execute_and_sync_command_bundle(cmd_bundle, UINT64_MAX);
 
-  for (uint32_t i = 0; i < total_size; i++) {
+  for (size_t i = 0U; i < total_size; i++) {
     ASSERT_EQ(static_cast<uint8_t *>(target_memory)[i], i % pattern_size)
         << "Memory Fill did not match.";
   }
@@ -1057,9 +1057,9 @@ protected:
 
     for (int region = 0; region < 3; region++) {
       // Define region to be copied from/to
-      auto width = widths[region];
-      auto height = heights[region];
-      auto depth = depths[region];
+      size_t width = widths[region];
+      size_t height = heights[region];
+      size_t depth = depths[region];
 
       ze_copy_region_t src_region;
       src_region.originX = 0;
@@ -1088,9 +1088,9 @@ protected:
       execute_and_sync_command_bundle(cmd_bundle, UINT64_MAX);
       reset_command_list(cmd_bundle.list);
 
-      for (int z = 0; z < depth; z++) {
-        for (int y = 0; y < height; y++) {
-          for (int x = 0; x < width; x++) {
+      for (size_t z = 0U; z < depth; z++) {
+        for (size_t y = 0U; y < height; y++) {
+          for (size_t x = 0U; x < width; x++) {
             // index calculated based on memory sized by rows * columns * slices
             size_t index = z * columns * rows + y * columns + x;
             uint8_t dest_val =
@@ -1167,9 +1167,9 @@ protected:
 
     for (int region = 0; region < 3; region++) {
       // Define region to be copied from/to
-      auto width = widths[region];
-      auto height = heights[region];
-      auto depth = depths[region];
+      size_t width = widths[region];
+      size_t height = heights[region];
+      size_t depth = depths[region];
 
       ze_copy_region_t src_region;
       src_region.originX = 0;
@@ -1198,9 +1198,9 @@ protected:
       execute_and_sync_command_bundle(cmd_bundle, UINT64_MAX);
       reset_command_list(cmd_bundle.list);
 
-      for (int z = 0; z < depth; z++) {
-        for (int y = 0; y < height; y++) {
-          for (int x = 0; x < width; x++) {
+      for (size_t z = 0U; z < depth; z++) {
+        for (size_t y = 0U; y < height; y++) {
+          for (size_t x = 0U; x < width; x++) {
             // index calculated based on memory sized by rows * columns * slices
             size_t index = z * columns * rows + y * columns + x;
             uint8_t dest_val =

--- a/conformance_tests/core/test_copy/src/test_copy_events.cpp
+++ b/conformance_tests/core/test_copy/src/test_copy_events.cpp
@@ -988,11 +988,11 @@ void RunGivenSuccessiveMemoryCopiesWithEventWhenExecutingOnDifferentQueuesTest(
     auto command_queue_groups = lzt::get_command_queue_group_properties(device);
 
     // we want to test copies with differing engines
-    std::vector<int> copy_ordinals;
-    for (int i = 0; i < command_queue_groups.size(); i++) {
+    std::vector<uint32_t> copy_ordinals;
+    for (size_t i = 0U; i < command_queue_groups.size(); i++) {
       if (command_queue_groups[i].flags &
           ZE_COMMAND_QUEUE_GROUP_PROPERTY_FLAG_COPY) {
-        copy_ordinals.push_back(i);
+        copy_ordinals.push_back(static_cast<uint32_t>(i));
       }
     }
 

--- a/conformance_tests/core/test_copy/src/test_copy_image.cpp
+++ b/conformance_tests/core/test_copy/src/test_copy_image.cpp
@@ -141,7 +141,7 @@ public:
                                             uint32_t image_height,
                                             uint32_t row_pitch) {
     if (image_width <= row_pitch) {
-      for (int row = 0; row < image_height; row++) {
+      for (uint32_t row = 0U; row < image_height; row++) {
         std::copy(padded_buffer + (row * row_pitch),
                   padded_buffer + (row * row_pitch) + image_width,
                   src_image_data + (row * image_width));
@@ -281,7 +281,7 @@ public:
     lzt::close_command_list(cmd_bundle.list);
     lzt::execute_and_sync_command_bundle(cmd_bundle, UINT64_MAX);
 
-    for (int i = 0; i < (image_size / 4); i++) {
+    for (uint32_t i = 0U; i < (image_size / 4); i++) {
       ASSERT_EQ(png_img_src.raw_data()[i], png_img_dest.raw_data()[i])
           << "i is " << i;
     }
@@ -300,12 +300,12 @@ public:
     lzt::ImagePNG32Bit out_image =
         lzt::ImagePNG32Bit(out_region.width, out_region.height);
 
-    for (auto y = 0; y < in_region.height; y++)
-      for (auto x = 0; x < in_region.width; x++)
+    for (uint32_t y = 0U; y < in_region.height; y++)
+      for (uint32_t x = 0U; x < in_region.width; x++)
         in_image.set_pixel(x, y, x + (y * in_region.width));
 
-    for (auto y = 0; y < out_region.height; y++)
-      for (auto x = 0; x < out_region.width; x++)
+    for (uint32_t y = 0U; y < out_region.height; y++)
+      for (uint32_t x = 0U; x < out_region.width; x++)
         out_image.set_pixel(x, y, 0xffffffff);
 
     // Copy from host image to to device image region

--- a/conformance_tests/core/test_device/src/test_affinity.cpp
+++ b/conformance_tests/core/test_device/src/test_affinity.cpp
@@ -237,8 +237,8 @@ LZT_TEST(
 
     // in each mask, either a device is present or it is not,
     // so for N devices there are 2^N possible masks
-    auto num_masks = 1 << num_leaf_devices;
-    for (uint32_t mask = 0; mask < num_masks; mask++) {
+    uint32_t num_masks = 1U << num_leaf_devices;
+    for (uint32_t mask = 0U; mask < num_masks; mask++) {
       uint32_t num_devices_mask = 0;
       auto temp = mask;
       while (temp) {
@@ -254,7 +254,7 @@ LZT_TEST(
       auto temp_mask = mask;
       std::string affinity_mask_string;
       uint16_t parent_index = 0;
-      for (int root_device = 0; root_device < devices.size(); root_device++) {
+      for (size_t root_device = 0U; root_device < devices.size(); root_device++) {
         uint16_t device_present = 0;
 
         auto temp_string = get_affinity_mask_string(
@@ -299,9 +299,9 @@ LZT_TEST(
 
     // in each mask, either a device is present or it is not,
     // so for N devices there are 2^N possible masks
-    auto num_masks = 1 << num_leaf_devices;
-    for (uint32_t mask = 0; mask < num_masks; mask++) {
-      uint32_t num_devices_mask = 0;
+    uint32_t num_masks = 1U << num_leaf_devices;
+    for (uint32_t mask = 0U; mask < num_masks; mask++) {
+      uint32_t num_devices_mask = 0U;
       auto temp = mask;
       while (temp) {
         num_devices_mask += temp & 0x1;
@@ -316,7 +316,7 @@ LZT_TEST(
       auto temp_mask = mask;
       std::string affinity_mask_string;
       uint16_t parent_index = 0;
-      for (int root_device = 0; root_device < devices.size(); root_device++) {
+      for (size_t root_device = 0U; root_device < devices.size(); root_device++) {
         uint16_t device_present = 0;
 
         auto temp_string = get_affinity_mask_string(
@@ -359,9 +359,9 @@ LZT_TEST(
 
     // in each mask, either a device is present or it is not,
     // so for N devices there are 2^N possible masks
-    auto num_masks = 1 << num_leaf_devices;
-    for (uint32_t mask = 0; mask < num_masks; mask++) {
-      uint32_t num_devices_mask = 0;
+    uint32_t num_masks = 1U << num_leaf_devices;
+    for (uint32_t mask = 0U; mask < num_masks; mask++) {
+      uint32_t num_devices_mask = 0U;
       auto temp = mask;
       while (temp) {
         num_devices_mask += temp & 0x1;
@@ -376,7 +376,7 @@ LZT_TEST(
       auto temp_mask = mask;
       std::string affinity_mask_string;
       uint16_t parent_index = 0;
-      for (int root_device = 0; root_device < devices.size(); root_device++) {
+      for (size_t root_device = 0U; root_device < devices.size(); root_device++) {
         uint16_t device_present = 0;
 
         auto temp_string = get_affinity_mask_string(
@@ -419,9 +419,9 @@ LZT_TEST(
 
     // in each mask, either a device is present or it is not,
     // so for N devices there are 2^N possible masks
-    auto num_masks = 1 << num_leaf_devices;
-    for (uint32_t mask = 0; mask < num_masks; mask++) {
-      uint32_t num_devices_mask = 0;
+    uint32_t num_masks = 1U << num_leaf_devices;
+    for (uint32_t mask = 0U; mask < num_masks; mask++) {
+      uint32_t num_devices_mask = 0U;
       auto temp = mask;
       while (temp) {
         num_devices_mask += temp & 0x1;
@@ -436,7 +436,7 @@ LZT_TEST(
       auto temp_mask = mask;
       std::string affinity_mask_string;
       uint16_t parent_index = 0;
-      for (int root_device = 0; root_device < devices.size(); root_device++) {
+      for (size_t root_device = 0U; root_device < devices.size(); root_device++) {
         uint16_t device_present = 0;
 
         auto temp_string = get_affinity_mask_string(
@@ -475,7 +475,7 @@ LZT_TEST(
   }
 
   uint32_t num_leaf_devices = 0;
-  for (int i = 0; i < devices.size(); i++) {
+  for (size_t i = 0U; i < devices.size(); i++) {
     num_leaf_devices += get_leaf_device_count(devices[i]);
   }
 

--- a/conformance_tests/core/test_device/src/test_device.cpp
+++ b/conformance_tests/core/test_device/src/test_device.cpp
@@ -80,7 +80,7 @@ static void run_child_process(uint32_t device_count,
 
   const std::string child_fail = "zeInit failed";
   std::vector<std::string> bdfString(device_count);
-  for (int i = 0; i < device_count; i++) {
+  for (uint32_t i = 0U; i < device_count; i++) {
     std::getline(child_output, bdfString[i]);
     // trim trailing whitespace from result_string
     bdfString[i].erase(std::find_if(bdfString[i].rbegin(), bdfString[i].rend(),
@@ -95,7 +95,7 @@ static void run_child_process(uint32_t device_count,
   std::vector<std::string> bdfStringSorted(bdfString.begin(), bdfString.end());
   std::sort(bdfStringSorted.begin(), bdfStringSorted.end(),
             comparePciIdBusNumber);
-  for (auto i = 0; i < device_count; i++) {
+  for (uint32_t i = 0U; i < device_count; i++) {
     EXPECT_STREQ(bdfString[i].c_str(), bdfStringSorted[i].c_str());
   }
 }
@@ -741,7 +741,7 @@ LZT_TEST_F(DevicePropertiesTest,
          iterSkuHandles->deviceHandlesForSku) {
       auto iterDeviceProperties = lzt::get_cache_properties(iterDeviceHandle);
       ASSERT_EQ(iterDeviceProperties.size(), firstDeviceProperties.size());
-      for (int i = 0; i < iterDeviceProperties.size(); i++) {
+      for (size_t i = 0U; i < iterDeviceProperties.size(); i++) {
         EXPECT_EQ(iterDeviceProperties[i].flags,
                   firstDeviceProperties[i].flags);
         EXPECT_EQ(iterDeviceProperties[i].cacheSize,
@@ -891,12 +891,12 @@ void RunGivenExecutedKernelWhenGettingGlobalTimestampsTest(bool is_immediate) {
   LOG_DEBUG << "Timestamps0: " << std::get<0>(timestamps) << "......"
             << std::get<1>(timestamps) << std::endl;
 
-  auto size = 10000000;
+  size_t size = 10000000;
   auto buffer_a = lzt::allocate_shared_memory(size, 0, 0, 0, device, context);
   auto buffer_b = lzt::allocate_device_memory(size, 0, 0, 0, device, context);
 
   std::memset(buffer_a, 0, size);
-  for (size_t i = 0; i < size; i++) {
+  for (size_t i = 0U; i < size; i++) {
     static_cast<uint8_t *>(buffer_a)[i] = (i & 0xFF);
   }
 
@@ -954,7 +954,7 @@ void RunGivenExecutedKernelWhenGettingGlobalTimestampsTest(bool is_immediate) {
   EXPECT_NE(device_time_0, device_time_1);
 
   // validation
-  for (size_t i = 0; i < size; i++) {
+  for (size_t i = 0U; i < size; i++) {
     ASSERT_EQ(static_cast<uint8_t *>(buffer_a)[i],
               static_cast<uint8_t>((i & 0xFF) + addval));
   }
@@ -1021,7 +1021,7 @@ LZT_TEST(
         lzt::get_command_queue_group_properties(device);
     EXPECT_EQ(cmd_q_group_properties_0.size(), cmd_q_group_properties_1.size());
 
-    for (int i = 0; i < cmd_q_group_properties_0.size(); i++) {
+    for (size_t i = 0U; i < cmd_q_group_properties_0.size(); i++) {
       EXPECT_EQ(cmd_q_group_properties_0[i].flags,
                 cmd_q_group_properties_1[i].flags);
       EXPECT_EQ(cmd_q_group_properties_0[i].maxMemoryFillPatternSize,
@@ -1049,7 +1049,7 @@ LZT_TEST(
       EXPECT_EQ(cmd_q_group_properties_0.size(),
                 cmd_q_group_properties_1.size());
 
-      for (int i = 0; i < cmd_q_group_properties_0.size(); i++) {
+      for (size_t i = 0U; i < cmd_q_group_properties_0.size(); i++) {
         EXPECT_EQ(cmd_q_group_properties_0[i].flags,
                   cmd_q_group_properties_1[i].flags);
         EXPECT_EQ(cmd_q_group_properties_0[i].maxMemoryFillPatternSize,

--- a/conformance_tests/core/test_event/src/test_event.cpp
+++ b/conformance_tests/core/test_event/src/test_event.cpp
@@ -183,7 +183,7 @@ LZT_TEST_F(
   auto events_initial = events;
   EXPECT_ZE_RESULT_SUCCESS(
       zeCommandListAppendWaitOnEvents(cmd_list, event_count, events.data()));
-  for (int i = 0; i < events.size(); i++) {
+  for (size_t i = 0U; i < events.size(); i++) {
     ASSERT_EQ(events[i], events_initial[i]);
   }
   ep.destroy_events(events);
@@ -215,7 +215,7 @@ protected:
     }
 
     context = lzt::create_context();
-    for (auto idx = 0; idx < dev_handles.size(); idx++) {
+    for (size_t idx = 0U; idx < dev_handles.size(); idx++) {
       cmdlist_immediate_handles.resize(dev_handles.size());
       cmd_lists.resize(dev_handles.size());
       cmd_qs.resize(dev_handles.size());
@@ -238,8 +238,8 @@ protected:
   }
 
   void TearDown() override {
-    auto num_handles = cmdlist_immediate_handles.size();
-    for (auto i = 0; i < num_handles; i++) {
+    size_t num_handles = cmdlist_immediate_handles.size();
+    for (size_t i = 0U; i < num_handles; i++) {
       if (use_immediate) {
         lzt::destroy_command_list(cmdlist_immediate_handles[i]);
       } else {
@@ -267,7 +267,7 @@ LZT_TEST_P(
   ze_event_handle_t event = nullptr;
 
   ep.InitEventPool(ep_desc, dev_handles);
-  for (auto i = 0; i < dev_handles.size(); i++) {
+  for (size_t i = 0U; i < dev_handles.size(); i++) {
     ep.create_event(event);
     if (use_immediate) {
       EXPECT_ZE_RESULT_SUCCESS(
@@ -287,17 +287,16 @@ LZT_TEST_P(
     zeSubDeviceCreateEventAndCommandListTests,
     GivenSubDeviceWhenChainingSignalEventToCommandListThenSuccessIsReturned) {
   std::vector<ze_event_handle_t> events(num_events);
-  for (auto i = 0; i < num_events; i++) {
+  for (uint64_t i = 0U; i < num_events; i++) {
     ep.create_event(events[i]);
   }
 
-  auto num_iters =
+  uint64_t num_iters =
       (num_events > dev_handles.size()) ? dev_handles.size() : num_events;
   if (num_iters < 1) {
     GTEST_SKIP() << "No subdevices found, skipping test";
   }
-  uint32_t i = 0;
-  for (i = 0; i < num_iters - 1; i++) {
+  for (uint32_t i = 0U; i < num_iters - 1; i++) {
     if (use_immediate) {
       EXPECT_ZE_RESULT_SUCCESS(zeCommandListAppendSignalEvent(
           cmdlist_immediate_handles[i], events[i]));
@@ -313,19 +312,20 @@ LZT_TEST_P(
 
   // For regular command lists, execute as batch
   if (!use_immediate) {
-    for (auto idx = 0; idx < num_iters; idx++) {
+    for (uint64_t idx = 0U; idx < num_iters; idx++) {
       lzt::close_command_list(cmd_lists[idx]);
       lzt::execute_command_lists(cmd_qs[idx], 1, &cmd_lists[idx], nullptr);
       lzt::synchronize(cmd_qs[idx], timeout);
     }
   } else {
     // Signal last event in queue and wait on host
+    uint64_t idx = num_iters - 1;
     EXPECT_ZE_RESULT_SUCCESS(zeCommandListAppendSignalEvent(
-        cmdlist_immediate_handles[i], events[i]));
-    EXPECT_ZE_RESULT_SUCCESS(zeEventHostSynchronize(events[i], timeout));
+        cmdlist_immediate_handles[idx], events[idx]));
+    EXPECT_ZE_RESULT_SUCCESS(zeEventHostSynchronize(events[idx], timeout));
   }
 
-  for (auto i = 0; i < num_events; i++) {
+  for (uint64_t i = 0U; i < num_events; i++) {
     ep.destroy_event(events[i]);
   }
 }
@@ -337,7 +337,7 @@ LZT_TEST_P(
   ze_event_handle_t event_imm = nullptr;
 
   ep.InitEventPool(ep_desc, dev_handles);
-  for (auto i = 0; i < dev_handles.size(); i++) {
+  for (size_t i = 0U; i < dev_handles.size(); i++) {
     ep.create_event(event);
     ep.create_event(event_imm);
     EXPECT_ZE_RESULT_SUCCESS(zeEventHostSignal(event));

--- a/conformance_tests/core/test_event/src/test_event_profiling.cpp
+++ b/conformance_tests/core/test_event/src/test_event_profiling.cpp
@@ -296,7 +296,7 @@ LZT_TEST_P(EventProfilingCacheCoherencyTests,
   std::unique_ptr<uint8_t> output(new uint8_t[size]);
   memcpy(output.get(), buffer5, size);
 
-  for (int i = 0; i < size; i++) {
+  for (uint32_t i = 0U; i < size; i++) {
     ASSERT_EQ(output.get()[i], value);
   }
 
@@ -378,7 +378,7 @@ void RunGivenKernelEventWhenUsingEventToSyncTest(bool is_immediate) {
   lzt::execute_and_sync_command_bundle(cmd_bundle, UINT64_MAX);
   lzt::event_host_synchronize(event, UINT64_MAX);
 
-  for (int i = 0; i < elems_nb; i++) {
+  for (uint32_t i = 0U; i < elems_nb; i++) {
     int value = ((int *)src_buffer)[i];
     ASSERT_EQ(value, addval);
   }

--- a/conformance_tests/core/test_fence/src/test_fence.cpp
+++ b/conformance_tests/core/test_fence/src/test_fence.cpp
@@ -170,7 +170,7 @@ LZT_TEST_P(
   auto cmdq_properties = lzt::get_command_queue_group_properties(device);
 
   size_t num_cmdq = 0;
-  std::vector<int> num_queues_per_group;
+  std::vector<uint32_t> num_queues_per_group;
   for (auto properties : cmdq_properties) {
     num_queues_per_group.push_back(properties.numQueues);
     num_cmdq += properties.numQueues;

--- a/conformance_tests/core/test_image/src/test_image_formats.cpp
+++ b/conformance_tests/core/test_image/src/test_image_formats.cpp
@@ -160,7 +160,7 @@ void zeImageFormatTypeTests::setup_buffers(ImageFormatFixture &test,
   test.outbuff = lzt::allocate_host_memory_with_allocator_selector(
       test.image_size * sizeof(T), is_shared_system);
   T *in_ptr = static_cast<T *>(test.inbuff);
-  for (int i = 0; i < test.image_size; i++) {
+  for (size_t i = 0U; i < test.image_size; i++) {
     in_ptr[i] = value;
   }
 }
@@ -172,7 +172,7 @@ void zeImageFormatTypeTests::setup_buffers_float(ImageFormatFixture &test,
   test.outbuff = lzt::allocate_host_memory_with_allocator_selector(
       test.image_size * sizeof(float), is_shared_system);
   float *in_ptr = static_cast<float *>(test.inbuff);
-  for (int i = 0; i < test.image_size; i++) {
+  for (size_t i = 0U; i < test.image_size; i++) {
     in_ptr[i] = float_pixel_input;
   }
 }
@@ -180,14 +180,14 @@ void zeImageFormatTypeTests::setup_buffers_float(ImageFormatFixture &test,
 template <typename T, T value>
 void zeImageFormatTypeTests::verify_outbuffer(ImageFormatFixture &test) {
   T *out_ptr = static_cast<T *>(test.outbuff);
-  for (int i = 0; i < test.image_size; i++) {
+  for (size_t i = 0U; i < test.image_size; i++) {
     EXPECT_EQ(out_ptr[i], value);
   }
 }
 
 void zeImageFormatTypeTests::verify_outbuffer_float(ImageFormatFixture &test) {
   float *out_ptr = static_cast<float *>(test.outbuff);
-  for (int i = 0; i < test.image_size; i++) {
+  for (size_t i = 0U; i < test.image_size; i++) {
     EXPECT_LT(out_ptr[i], 3.5);
     EXPECT_GT(out_ptr[i], 3.0);
   }
@@ -427,9 +427,9 @@ class zeImageFormatLayoutTests
       public ::testing::WithParamInterface<
           std::tuple<ze_image_type_t, ze_image_format_layout_t, bool>> {
 public:
-  template <typename T, int size_multiplier = 1>
+  template <typename T, size_t size_multiplier = 1>
   static void set_up_buffers(ImageFormatFixture &test, bool is_shared_system);
-  template <typename T, bool saturates = true, int size_multiplier = 1>
+  template <typename T, bool saturates = true, size_t size_multiplier = 1>
   static void verify_buffer(ImageFormatFixture &test);
   template <typename T, bool saturates = true>
   static void verify_buffer_float(ImageFormatFixture &test);
@@ -514,7 +514,7 @@ void zeImageFormatLayoutTests::get_kernel(ze_image_type_t image_type,
   kernel_name += '_' + shortened_string(image_type);
 }
 
-template <typename T, int size_multiplier>
+template <typename T, size_t size_multiplier>
 void zeImageFormatLayoutTests::set_up_buffers(ImageFormatFixture &test,
                                               bool is_shared_system) {
   test.inbuff = lzt::allocate_host_memory_with_allocator_selector(
@@ -522,7 +522,7 @@ void zeImageFormatLayoutTests::set_up_buffers(ImageFormatFixture &test,
   test.outbuff = lzt::allocate_host_memory_with_allocator_selector(
       (test.image_size * sizeof(T) * size_multiplier), is_shared_system);
   T *in_ptr = static_cast<T *>(test.inbuff);
-  for (int i = 0; i < (test.image_size * size_multiplier); i++) {
+  for (size_t i = 0U; i < (test.image_size * size_multiplier); i++) {
     // set pixel value to 1 less than max for data type so
     // that when the kernel increments it, it saturates
     // or rolls over
@@ -530,11 +530,11 @@ void zeImageFormatLayoutTests::set_up_buffers(ImageFormatFixture &test,
   }
 }
 
-template <typename T, bool saturates, int size_multiplier>
+template <typename T, bool saturates, size_t size_multiplier>
 void zeImageFormatLayoutTests::verify_buffer(ImageFormatFixture &test) {
   auto max_val = std::numeric_limits<T>::max();
   T *out_ptr = static_cast<T *>(test.outbuff);
-  for (int i = 0; i < (test.image_size * size_multiplier); i++) {
+  for (size_t i = 0U; i < (test.image_size * size_multiplier); i++) {
     if (saturates) {
       ASSERT_EQ(out_ptr[i], max_val);
     } else if (max_val == std::numeric_limits<uint64_t>::max()) {
@@ -550,7 +550,7 @@ void zeImageFormatLayoutTests::verify_buffer(ImageFormatFixture &test) {
 template <typename T, bool saturates>
 void zeImageFormatLayoutTests::verify_buffer_float(ImageFormatFixture &test) {
   T *out_ptr = static_cast<T *>(test.outbuff);
-  for (int i = 0; i < test.image_size; i++) {
+  for (size_t i = 0U; i < test.image_size; i++) {
     if (saturates) {
       ASSERT_EQ(out_ptr[i], std::numeric_limits<T>::max());
     } else {

--- a/conformance_tests/core/test_image/src/test_image_swizzle.cpp
+++ b/conformance_tests/core/test_image/src/test_image_swizzle.cpp
@@ -76,7 +76,7 @@ void zeCommandListAppendImageCopyWithSwizzleTests::run_test(
       (uint32_t *)lzt::allocate_host_memory_with_allocator_selector(
           image_size * sizeof(uint32_t), is_shared_system);
 
-  for (int i = 0; i < image_size; i++) {
+  for (size_t i = 0U; i < image_size; i++) {
     inbuff[i] = 0x12345678;
   }
 
@@ -104,7 +104,7 @@ void zeCommandListAppendImageCopyWithSwizzleTests::run_test(
   lzt::close_command_list(bundle.list);
   lzt::execute_and_sync_command_bundle(bundle, UINT64_MAX);
 
-  for (int i = 0; i < image_size; i++) {
+  for (size_t i = 0U; i < image_size; i++) {
     EXPECT_EQ(outbuff[i], 0x78563412); // After swizzle from RGBA to AGBR the
                                        // data format will be reversed from 12
                                        // 34 56 78 -> 78 56 34 12

--- a/conformance_tests/core/test_ipc/src/test_ipc_event_helper.cpp
+++ b/conformance_tests/core/test_ipc/src/test_ipc_event_helper.cpp
@@ -141,7 +141,7 @@ static void child_host_query_timestamp(const ze_event_pool_handle_t &hEventPool,
     lzt::get_event_kernel_timestamps_from_mapped_timestamp_event(
         hEvent, device, kernel_timestamp_buffer, synchronized_timestamp_buffer);
 
-    for (int i = 0; i < kernel_timestamp_buffer.size(); i++) {
+    for (size_t i = 0U; i < kernel_timestamp_buffer.size(); i++) {
       if (!i) {
         LOG_INFO << "IPC Child set timestamp value";
         shared_data.start_time =

--- a/conformance_tests/core/test_ipc/src/test_ipc_memory_helper.cpp
+++ b/conformance_tests/core/test_ipc/src/test_ipc_memory_helper.cpp
@@ -71,7 +71,7 @@ static void child_subdevice_access_test(int size, ze_ipc_memory_flags_t flags,
   auto device = lzt::zeDevice::get_instance()->get_device();
   auto sub_devices = lzt::get_ze_sub_devices(device);
 
-  auto sub_device_count = sub_devices.size();
+  size_t sub_device_count = sub_devices.size();
 
   ze_ipc_mem_handle_t ipc_handle;
   void *memory = nullptr;
@@ -93,7 +93,7 @@ static void child_subdevice_access_test(int size, ze_ipc_memory_flags_t flags,
   memset(buffer, 0, size);
 
   // For each sub device found, use IPC buffer in a copy operation and validate
-  for (auto i = 0; i < sub_device_count; i++) {
+  for (size_t i = 0U; i < sub_device_count; i++) {
     auto cmd_bundle =
         lzt::create_command_bundle(context, sub_devices[i], is_immediate);
 
@@ -161,7 +161,7 @@ static void child_subdevice_access_test_opaque(int size,
   auto device = lzt::zeDevice::get_instance()->get_device();
   auto sub_devices = lzt::get_ze_sub_devices(device);
 
-  auto sub_device_count = sub_devices.size();
+  size_t sub_device_count = sub_devices.size();
 
   auto cmd_bundle = lzt::create_command_bundle(context, device, is_immediate);
   void *memory = nullptr;
@@ -172,7 +172,7 @@ static void child_subdevice_access_test_opaque(int size,
   void *buffer = lzt::allocate_host_memory(size, 1, context);
   memset(buffer, 0, size);
   // For each sub device found, use IPC buffer in a copy operation and validate
-  for (auto i = 0; i < sub_device_count; i++) {
+  for (size_t i = 0U; i < sub_device_count; i++) {
     auto cmd_bundle =
         lzt::create_command_bundle(context, sub_devices[i], is_immediate);
 

--- a/conformance_tests/core/test_ipc/src/test_ipc_p2p_memory.cpp
+++ b/conformance_tests/core/test_ipc/src/test_ipc_p2p_memory.cpp
@@ -53,9 +53,9 @@ void init_driver() {
   LOG_DEBUG << "Driver initialized\n";
 }
 
-void fill_expected_buffer(char *expected_buffer, const int size,
-                          const int concurrency_offset, const bool is_server) {
-  if (concurrency_offset > 0) {
+void fill_expected_buffer(char *expected_buffer, const size_t size,
+                          const size_t concurrency_offset, const bool is_server) {
+  if (concurrency_offset > 0U) {
     for (size_t i = 0; i < size - concurrency_offset; ++i) {
       if (is_server) {
         expected_buffer[i] = client_pattern;
@@ -71,7 +71,7 @@ void fill_expected_buffer(char *expected_buffer, const int size,
       }
     }
   } else {
-    for (size_t i = 0; i < size; ++i) {
+    for (size_t i = 0U; i < size; ++i) {
       if (is_server) {
         expected_buffer[i] = client_pattern;
       } else {
@@ -85,7 +85,7 @@ inline void init_process(ze_context_handle_t &context,
                          ze_device_handle_t &device,
                          std::vector<lzt::zeCommandBundle> &cmd_bundles,
                          bool is_server, uint32_t device_x, uint32_t device_y,
-                         int concurrency_offset, bool is_immediate) {
+                         size_t concurrency_offset, bool is_immediate) {
   init_driver();
 
   auto driver = lzt::get_default_driver();
@@ -108,7 +108,7 @@ inline void init_process(ze_context_handle_t &context,
     std::exit(0);
   }
 
-  if (concurrency_offset > 0) {
+  if (concurrency_offset > 0U) {
     ze_device_p2p_properties_t peerProperties = {};
     peerProperties.stype = ZE_STRUCTURE_TYPE_DEVICE_P2P_PROPERTIES;
 
@@ -154,8 +154,8 @@ inline void init_process(ze_context_handle_t &context,
   }
 }
 
-void run_server(int size, uint32_t device_x, uint32_t device_y,
-                int concurrency_offset, bool bidirectional, pid_t pid,
+void run_server(size_t size, uint32_t device_x, uint32_t device_y,
+                size_t concurrency_offset, bool bidirectional, pid_t pid,
                 bool is_immediate) {
   ze_context_handle_t context;
   ze_device_handle_t device;
@@ -186,7 +186,7 @@ void run_server(int size, uint32_t device_x, uint32_t device_y,
     lzt::get_ipc_handle(context, &ipc_handle, memory);
     lzt::send_ipc_handle(ipc_handle);
 
-    if (concurrency_offset > 0) {
+    if (concurrency_offset > 0U) {
       void *buffer = lzt::allocate_device_memory(size - concurrency_offset, 1,
                                                  0, device, context);
       lzt::append_memory_fill(cb.list, buffer, &server_pattern,
@@ -258,8 +258,8 @@ void run_server(int size, uint32_t device_x, uint32_t device_y,
   std::exit(0);
 }
 
-void run_client(int size, uint32_t device_x, uint32_t device_y,
-                int concurrency_offset, bool bidirectional, pid_t ppid,
+void run_client(size_t size, uint32_t device_x, uint32_t device_y,
+                size_t concurrency_offset, bool bidirectional, pid_t ppid,
                 bool is_immediate) {
   ze_context_handle_t context;
   ze_device_handle_t device;
@@ -380,9 +380,9 @@ LZT_TEST_P(
     if (pid < 0) {
       throw std::runtime_error("Failed to fork child process");
     } else if (pid > 0) {
-      run_server(size, device_x, device_y, 0, false, pid, is_immediate);
+      run_server(size, device_x, device_y, 0U, false, pid, is_immediate);
     } else {
-      run_client(size, device_x, device_y, 0, false, ppid, is_immediate);
+      run_client(size, device_x, device_y, 0U, false, ppid, is_immediate);
     }
   }
 }
@@ -415,9 +415,9 @@ LZT_TEST_P(
     if (pid < 0) {
       throw std::runtime_error("Failed to fork child process");
     } else if (pid > 0) {
-      run_server(size, device_x, device_y, 0, true, pid, is_immediate);
+      run_server(size, device_x, device_y, 0U, true, pid, is_immediate);
     } else {
-      run_client(size, device_x, device_y, 0, true, ppid, is_immediate);
+      run_client(size, device_x, device_y, 0U, true, ppid, is_immediate);
     }
   }
 }
@@ -425,8 +425,8 @@ LZT_TEST_P(
 LZT_TEST_P(
     P2PIpcMemoryAccessTest,
     GivenTwoDevicesAndL0MemoryAllocatedInDeviceXExportedToDeviceYWhenUsingL0IPCP2PThenExportedMemoryAllocationUpdatedByBothDeviceXAndDeviceYConcurrently) {
-  size_t size = std::pow(2, std::get<0>(GetParam()));
-  size_t concurrency_offset = std::pow(2, std::get<0>(GetParam()) - 1);
+  size_t size = 1UL << std::get<0>(GetParam());
+  size_t concurrency_offset = size >> 1;
   uint32_t device_x = std::get<1>(GetParam());
   uint32_t device_y = std::get<2>(GetParam());
   bool is_immediate = std::get<3>(GetParam());

--- a/conformance_tests/core/test_ipc/src/test_ipc_put_handle_helper.cpp
+++ b/conformance_tests/core/test_ipc/src/test_ipc_put_handle_helper.cpp
@@ -66,7 +66,7 @@ static void child_put_subdevice_test(int size, ze_ipc_memory_flags_t flags,
   auto device = lzt::zeDevice::get_instance()->get_device();
   auto sub_devices = lzt::get_ze_sub_devices(device);
 
-  auto sub_device_count = sub_devices.size();
+  size_t sub_device_count = sub_devices.size();
 
   ze_ipc_mem_handle_t ipc_handle;
   void *memory = nullptr;
@@ -84,7 +84,7 @@ static void child_put_subdevice_test(int size, ze_ipc_memory_flags_t flags,
   memset(buffer, 0, size);
 
   // For each sub device found, use IPC buffer in a copy operation and validate
-  for (auto i = 0; i < sub_device_count; i++) {
+  for (size_t i = 0U; i < sub_device_count; i++) {
     auto cmd_bundle =
         lzt::create_command_bundle(context, sub_devices[i], is_immediate);
 

--- a/conformance_tests/core/test_memory/src/test_memory_export_import.cpp
+++ b/conformance_tests/core/test_memory/src/test_memory_export_import.cpp
@@ -515,7 +515,7 @@ void memory_import_thread(thread_args *args) {
       context, device, 0, ZE_COMMAND_QUEUE_MODE_DEFAULT,
       ZE_COMMAND_QUEUE_PRIORITY_NORMAL, 0, 0, 0, args->is_immediate);
 
-  auto size = 1024;
+  size_t size = 1024;
   void *imported_memory = nullptr;
   ze_image_handle_t image_handle;
   ASSERT_ZE_RESULT_SUCCESS(import_memory(context, device, size, args->fd,
@@ -534,7 +534,7 @@ void memory_import_thread(thread_args *args) {
   lzt::close_command_list(cmd_bundle.list);
   lzt::execute_and_sync_command_bundle(cmd_bundle, UINT64_MAX);
 
-  for (size_t i = 0; i < size; i++) {
+  for (size_t i = 0U; i < size; i++) {
     EXPECT_EQ(static_cast<uint8_t *>(verification_memory)[i],
               0xAB); // this pattern is written in test_import_helper
   }
@@ -659,7 +659,7 @@ void zeDeviceGetExternalMemoryProperties::
       get_imported_fd(lzt::to_string(driver_properties.uuid), child_input,
                       is_immediate, test_memory_type);
 
-  auto size = 1024;
+  size_t size = 1024;
   void *imported_memory = nullptr;
   ze_image_handle_t image_handle;
   ASSERT_ZE_RESULT_SUCCESS(import_memory(context, device, size, imported_fd,
@@ -683,7 +683,7 @@ void zeDeviceGetExternalMemoryProperties::
   child_input << "Done"
               << std::endl; // The content of this message doesn't really matter
 
-  for (size_t i = 0; i < size; i++) {
+  for (size_t i = 0U; i < size; i++) {
     EXPECT_EQ(static_cast<uint8_t *>(verification_memory)[i],
               0xAB); // this pattern is written in test_import_helper
   }

--- a/conformance_tests/core/test_memory/src/test_virtual_memory.cpp
+++ b/conformance_tests/core/test_memory/src/test_virtual_memory.cpp
@@ -344,7 +344,7 @@ void RunGivenMappedReadWriteMemoryThenFillAndCopyWithMappedVirtualMemory(
   lzt::close_command_list(bundle.list);
   lzt::execute_and_sync_command_bundle(bundle, UINT64_MAX);
   uint8_t *data = reinterpret_cast<uint8_t *>(memory);
-  for (int i = 0; i < test.allocationSize; i++) {
+  for (size_t i = 0U; i < test.allocationSize; i++) {
     ASSERT_EQ(data[i], pattern);
   }
 
@@ -418,7 +418,7 @@ void RunGivenMappedMultiplePhysicalMemoryAcrossAvailableDevicesWhenFillAndCopyWi
   test.allocationSize = test.pageSize;
   test.allocationSize =
       lzt::create_page_aligned_size(test.allocationSize, test.pageSize);
-  for (int i = 0; i < devices.size(); i++) {
+  for (size_t i = 0U; i < devices.size(); i++) {
     lzt::physical_device_memory_allocation(test.context, devices[i],
                                            test.allocationSize,
                                            &reservedPhysicalMemoryArray[i]);
@@ -432,7 +432,7 @@ void RunGivenMappedMultiplePhysicalMemoryAcrossAvailableDevicesWhenFillAndCopyWi
   EXPECT_NE(nullptr, test.reservedVirtualMemory);
 
   size_t offset = 0;
-  for (int i = 0; i < devices.size(); i++) {
+  for (size_t i = 0U; i < devices.size(); i++) {
     void *reservedVirtualMemoryOffset = reinterpret_cast<void *>(
         reinterpret_cast<uint64_t>(test.reservedVirtualMemory) + offset);
     ASSERT_ZE_RESULT_SUCCESS(
@@ -453,11 +453,11 @@ void RunGivenMappedMultiplePhysicalMemoryAcrossAvailableDevicesWhenFillAndCopyWi
   lzt::close_command_list(bundle.list);
   lzt::execute_and_sync_command_bundle(bundle, UINT64_MAX);
   uint8_t *data = reinterpret_cast<uint8_t *>(memory);
-  for (int i = 0; i < totalAllocationSize; i++) {
+  for (size_t i = 0U; i < totalAllocationSize; i++) {
     ASSERT_EQ(data[i], pattern);
   }
   offset = 0;
-  for (int i = 0; i < devices.size(); i++) {
+  for (size_t i = 0U; i < devices.size(); i++) {
     void *reservedVirtualMemoryOffset = reinterpret_cast<void *>(
         reinterpret_cast<uint64_t>(test.reservedVirtualMemory) + offset);
     lzt::virtual_memory_unmap(test.context, reservedVirtualMemoryOffset,
@@ -487,12 +487,12 @@ LZT_TEST_F(
 
 void RunGivenVirtualMemoryMappedToMultipleAllocationsWhenFullAddressUsageInKernel(
     zeVirtualMemoryTests &test, bool is_immediate) {
-  int numDevices = lzt::get_ze_device_count();
+  uint32_t numDevices = lzt::get_ze_device_count();
   std::vector<ze_device_handle_t> devices;
   std::vector<ze_physical_mem_handle_t> reservedPhysicalMemoryArray;
   devices = lzt::get_ze_devices(numDevices);
   reservedPhysicalMemoryArray.resize(numDevices);
-  if (numDevices == 1) {
+  if (numDevices == 1U) {
     reservedPhysicalMemoryArray.resize(2);
     devices.resize(2);
     devices[0] = test.device;
@@ -505,7 +505,7 @@ void RunGivenVirtualMemoryMappedToMultipleAllocationsWhenFullAddressUsageInKerne
   test.allocationSize = test.pageSize;
   test.allocationSize =
       lzt::create_page_aligned_size(test.allocationSize, test.pageSize);
-  for (int i = 0; i < devices.size(); i++) {
+  for (size_t i = 0U; i < devices.size(); i++) {
     lzt::physical_device_memory_allocation(test.context, devices[i],
                                            test.allocationSize,
                                            &reservedPhysicalMemoryArray[i]);
@@ -518,7 +518,7 @@ void RunGivenVirtualMemoryMappedToMultipleAllocationsWhenFullAddressUsageInKerne
   EXPECT_NE(nullptr, test.reservedVirtualMemory);
 
   size_t offset = 0;
-  for (int i = 0; i < devices.size(); i++) {
+  for (size_t i = 0U; i < devices.size(); i++) {
     void *reservedVirtualMemoryOffset = reinterpret_cast<void *>(
         reinterpret_cast<uint64_t>(test.reservedVirtualMemory) + offset);
     ASSERT_ZE_RESULT_SUCCESS(
@@ -588,7 +588,7 @@ void RunGivenVirtualMemoryMappedToMultipleAllocationsWhenFullAddressUsageInKerne
   lzt::destroy_function(function);
   lzt::destroy_module(module);
   offset = 0;
-  for (int i = 0; i < devices.size(); i++) {
+  for (size_t i = 0U; i < devices.size(); i++) {
     void *reservedVirtualMemoryOffset = reinterpret_cast<void *>(
         reinterpret_cast<uint64_t>(test.reservedVirtualMemory) + offset);
     lzt::virtual_memory_unmap(test.context, reservedVirtualMemoryOffset,
@@ -667,7 +667,7 @@ void dataCheckMemoryReservations(enum MemoryReservationTestType type,
 
   lzt::query_page_size(context, rootDevice, allocationSize, &pageSize);
   allocationSize = lzt::create_page_aligned_size(allocationSize, pageSize);
-  for (int i = 0; i < devices.size(); i++) {
+  for (size_t i = 0U; i < devices.size(); i++) {
     lzt::physical_device_memory_allocation(context, devices[i], allocationSize,
                                            &reservedPhysicalMemory[i]);
   }
@@ -678,7 +678,7 @@ void dataCheckMemoryReservations(enum MemoryReservationTestType type,
   EXPECT_NE(nullptr, reservedVirtualMemory);
 
   size_t offset = 0;
-  for (int i = 0; i < devices.size(); i++) {
+  for (size_t i = 0U; i < devices.size(); i++) {
     uint64_t offsetAddr =
         reinterpret_cast<uint64_t>(reservedVirtualMemory) + offset;
     ASSERT_ZE_RESULT_SUCCESS(zeVirtualMemMap(
@@ -692,7 +692,7 @@ void dataCheckMemoryReservations(enum MemoryReservationTestType type,
       lzt::allocate_host_memory(allocationSize * devices.size(), pageSize);
 
   offset = 0;
-  for (int i = 0; i < devices.size(); i++) {
+  for (size_t i = 0U; i < devices.size(); i++) {
     uint64_t offsetAddr =
         reinterpret_cast<uint64_t>(reservedVirtualMemory) + offset;
     lzt::append_memory_fill(bundle.list, reinterpret_cast<void *>(offsetAddr),
@@ -703,7 +703,7 @@ void dataCheckMemoryReservations(enum MemoryReservationTestType type,
   lzt::append_barrier(bundle.list, nullptr, 0, nullptr);
 
   offset = 0;
-  for (int i = 0; i < devices.size(); i++) {
+  for (size_t i = 0U; i < devices.size(); i++) {
     uint64_t offsetAddr =
         reinterpret_cast<uint64_t>(reservedVirtualMemory) + offset;
     uint64_t offsetHostAddr = reinterpret_cast<uint64_t>(memory) + offset;
@@ -716,14 +716,14 @@ void dataCheckMemoryReservations(enum MemoryReservationTestType type,
   lzt::close_command_list(bundle.list);
   lzt::execute_and_sync_command_bundle(bundle, UINT64_MAX);
   uint8_t *data = reinterpret_cast<uint8_t *>(memory);
-  for (int i = 0; i < allocationSize * devices.size(); i++) {
+  for (size_t i = 0U; i < allocationSize * devices.size(); i++) {
     ASSERT_EQ(data[i], pattern);
   }
 
   lzt::virtual_memory_unmap(context, reservedVirtualMemory, allocationSize);
 
   offset = 0;
-  for (int i = 0; i < devices.size(); i++) {
+  for (size_t i = 0U; i < devices.size(); i++) {
     uint64_t offsetAddr =
         reinterpret_cast<uint64_t>(reservedVirtualMemory) + offset;
     lzt::virtual_memory_unmap(context, reinterpret_cast<void *>(offsetAddr),

--- a/conformance_tests/core/test_module/src/test_cooperative_kernel.cpp
+++ b/conformance_tests/core/test_module/src/test_cooperative_kernel.cpp
@@ -42,7 +42,7 @@ void CooperativeKernelTests::
 
   auto command_queue_group_properties =
       lzt::get_command_queue_group_properties(device);
-  for (int i = 0; i < command_queue_group_properties.size(); i++) {
+  for (size_t i = 0; i < command_queue_group_properties.size(); i++) {
     if (command_queue_group_properties[i].flags &
         ZE_COMMAND_QUEUE_GROUP_PROPERTY_FLAG_COOPERATIVE_KERNELS) {
       ordinal = i;
@@ -66,7 +66,7 @@ void CooperativeKernelTests::
 
   memcpy(input_data, kernel_data, data_size * sizeof(uint64_t));
 
-  auto row_num = std::get<0>(GetParam());
+  uint32_t row_num = std::get<0>(GetParam());
   uint32_t groups_x = 1;
 
   module = lzt::create_module(context, device, "cooperative_kernel.spv",
@@ -99,7 +99,7 @@ void CooperativeKernelTests::
 
   // Validate the kernel completed successfully and correctly
   uint64_t val = 0;
-  for (int i = 0; i <= row_num; i++) {
+  for (uint32_t i = 0U; i <= row_num; i++) {
     val = i + row_num;
     ASSERT_EQ(static_cast<uint64_t *>(input_data)[i], val);
   }

--- a/conformance_tests/core/test_module/src/test_module.cpp
+++ b/conformance_tests/core/test_module/src/test_module.cpp
@@ -497,7 +497,7 @@ void zeModuleCreateTests::
                                    buff_spec, is_immediate);
   uint64_t *output = static_cast<uint64_t *>(buff_spec);
 
-  for (int i = 0; i < spec_constants_num; i++) {
+  for (uint32_t i = 0U; i < spec_constants_num; i++) {
     int expected = (i + 1) * 11 + 1;
     int actual = output[i];
     EXPECT_EQ(expected, actual);
@@ -910,7 +910,7 @@ protected:
       EXPECT_ZE_RESULT_SUCCESS(zeCommandListAppendLaunchMultipleKernelsIndirect(
           bundle.list, 2, function_list.data(), num_launch_arg, mult_tg_dim,
           signal_event, num_wait, p_wait_events));
-      for (int i = 0; i < function_list.size(); i++) {
+      for (size_t i = 0U; i < function_list.size(); i++) {
         ASSERT_EQ(function_list[i], functions_initial[i]);
       }
 
@@ -918,7 +918,7 @@ protected:
       num_launch_arg[0] = 2;
       memcpy(args_buff, arg_buffer_list.data(), 2 * sizeof(ze_group_count_t));
     }
-    for (int i = 0; i < events_host_to_kernel.size(); i++) {
+    for (size_t i = 0U; i < events_host_to_kernel.size(); i++) {
       EXPECT_EQ(events_host_to_kernel[i], wait_events_initial[i]);
     }
     EXPECT_ZE_RESULT_SUCCESS(
@@ -1432,7 +1432,7 @@ void zeKernelLaunchTests::RunGivenBufferLargerThan4GBWhenExecutingFunction(
       if (comparison) {
         LOG_DEBUG << "Failed at offset: " << offset << std::endl;
         LOG_DEBUG << "Finding Incorrect Value";
-        for (int j = 0; j < validation_buffer_size; j++) {
+        for (size_t j = 0U; j < validation_buffer_size; j++) {
           if (validation_buffer[j] != reference_buffer[j]) {
             LOG_DEBUG << "index: " << std::dec << j << " val: " << std::hex
                       << (int)validation_buffer[j] << "\tref: " << std::hex
@@ -1524,15 +1524,15 @@ LZT_TEST_P(
     GTEST_SKIP();
   }
 
-  auto base_size = 8;
-  auto size = base_size * base_size * base_size;
+  uint32_t base_size = 8;
+  uint32_t size = base_size * base_size * base_size;
 
   auto buffer_a = lzt::allocate_shared_memory(size, 0, 0, 0, device, context);
   auto buffer_b = lzt::allocate_device_memory(size, 0, 0, device, context);
   std::memset(buffer_a, 0, size);
-  for (int x = 0; x < base_size; x++) {
-    for (int y = 0; y < base_size; y++) {
-      for (int z = 0; z < base_size; z++) {
+  for (uint32_t x = 0U; x < base_size; x++) {
+    for (uint32_t y = 0U; y < base_size; y++) {
+      for (uint32_t z = 0U; z < base_size; z++) {
         auto index = x + base_size * y + base_size * base_size * z;
         static_cast<uint8_t *>(buffer_a)[index] = (index & 0xFF);
       }
@@ -1585,11 +1585,11 @@ LZT_TEST_P(
   lzt::execute_and_sync_command_bundle(bundle, UINT64_MAX);
 
   // validation
-  for (int x = 0; x < base_size; x++) {
-    for (int y = 0; y < base_size; y++) {
-      for (int z = 0; z < base_size; z++) {
+  for (uint32_t x = 0U; x < base_size; x++) {
+    for (uint32_t y = 0U; y < base_size; y++) {
+      for (uint32_t z = 0U; z < base_size; z++) {
 
-        auto index = x + base_size * y + base_size * base_size * z;
+        uint32_t index = x + base_size * y + base_size * base_size * z;
 
         uint8_t val = 0;
         if (x >= offset_x && y >= offset_y && z >= offset_z) {

--- a/conformance_tests/core/test_multiprocess/src/test_multi_device_multi_process.cpp
+++ b/conformance_tests/core/test_multiprocess/src/test_multi_device_multi_process.cpp
@@ -32,7 +32,7 @@ void RunGivenMultipleProcessesUsingMultipleDevicesKernelsTest(
   std::vector<fs::path> paths;
   paths.push_back(helper_path);
 
-  for (int i = 0; i < num_processes; i++) {
+  for (size_t i = 0U; i < num_processes; i++) {
     auto env = boost::this_process::environment();
     bp::environment child_env = env;
     child_env["ZE_ENABLE_PCI_ID_DEVICE_ORDER"] = "1";
@@ -46,7 +46,7 @@ void RunGivenMultipleProcessesUsingMultipleDevicesKernelsTest(
   }
 
   // verification
-  for (int i = 0; i < num_processes; i++) {
+  for (size_t i = 0U; i < num_processes; i++) {
     processes[i].wait();
     int result = processes[i].exit_code();
     EXPECT_EQ(result, 0);

--- a/conformance_tests/core/test_multithread/src/test_allocation_residency_multithread.cpp
+++ b/conformance_tests/core/test_multithread/src/test_allocation_residency_multithread.cpp
@@ -62,7 +62,7 @@ void make_resident_evict_device_memory() {
 void make_resident_evict_API(ze_module_handle_t module) {
   ze_kernel_handle_t kernel;
 
-  for (uint32_t i = 0; i < thread_iters; i++) {
+  for (uint32_t j = 0U; j < thread_iters; j++) {
     auto context = lzt::get_default_context();
     auto driver = lzt::get_default_driver();
     auto device = lzt::get_default_device(driver);
@@ -79,7 +79,7 @@ void make_resident_evict_API(ze_module_handle_t module) {
         sizeof(node), 1, device_flags, host_flags, device, context));
     data->value = 0;
     node *temp = data;
-    for (int i = 0; i < size; i++) {
+    for (size_t i = 0U; i < size; i++) {
       temp->next = static_cast<node *>(lzt::allocate_shared_memory(
           sizeof(node), 1, device_flags, host_flags, device, context));
       temp = temp->next;
@@ -100,7 +100,7 @@ void make_resident_evict_API(ze_module_handle_t module) {
 
     temp = data->next;
     node *temp2;
-    for (int i = 0; i < size; i++) {
+    for (size_t i = 0U; i < size; i++) {
       temp2 = temp->next;
       lzt::make_memory_resident(device, temp, sizeof(node));
       temp = temp2;
@@ -110,7 +110,7 @@ void make_resident_evict_API(ze_module_handle_t module) {
     lzt::synchronize(command_queue, UINT64_MAX);
 
     temp = data->next;
-    for (int i = 0; i < size; i++) {
+    for (size_t i = 0U; i < size; i++) {
       lzt::evict_memory(device, temp, sizeof(node));
       temp = temp->next;
     }
@@ -118,7 +118,7 @@ void make_resident_evict_API(ze_module_handle_t module) {
     // cleanup
     temp = data;
     // total of size elements linked *after* initial element
-    for (int i = 0; i < size + 1; i++) {
+    for (size_t i = 0U; i < size + 1; i++) {
       // the kernel increments each node's value by 1
       ASSERT_EQ(temp->value, i + 1);
 
@@ -146,7 +146,7 @@ void indirect_access_Kernel(ze_module_handle_t module, bool is_immediate) {
   node *data = static_cast<node *>(lzt::allocate_shared_memory(
       sizeof(node), 1, device_flags, host_flags, device, context));
   node *temp = data;
-  for (int i = 0; i < size; i++) {
+  for (size_t i = 0U; i < size; i++) {
     temp->next = static_cast<node *>(lzt::allocate_shared_memory(
         sizeof(node), 1, device_flags, host_flags, device, context));
     temp = temp->next;
@@ -154,12 +154,12 @@ void indirect_access_Kernel(ze_module_handle_t module, bool is_immediate) {
 
   // init
   temp = data;
-  for (int i = 0; i < size + 1; i++) {
+  for (size_t i = 0U; i < size + 1; i++) {
     temp->value = i;
     temp = temp->next;
   }
 
-  for (uint32_t iter = 0; iter < thread_iters; iter++) {
+  for (size_t iter = 0U; iter < thread_iters; iter++) {
     // set up
     auto cmd_bundle = lzt::create_command_bundle(device, is_immediate);
     kernel = lzt::create_function(module, ZE_KERNEL_FLAG_FORCE_RESIDENCY,
@@ -183,7 +183,7 @@ void indirect_access_Kernel(ze_module_handle_t module, bool is_immediate) {
 
     // check
     temp = data;
-    for (int i = 0; i < size + 1; i++) {
+    for (size_t i = 0U; i < size + 1; i++) {
       // kernel should increment each node's value by 1
       ASSERT_EQ(temp->value, i + iter + 1);
       temp = temp->next;
@@ -204,7 +204,7 @@ void indirect_access_Kernel(ze_module_handle_t module, bool is_immediate) {
   }
 
   // cleanup
-  for (int i = 0; i < size + 1; i++) {
+  for (size_t i = 0U; i < size + 1; i++) {
     temp = data;
     data = temp->next;
     lzt::free_memory(context, temp);
@@ -220,12 +220,12 @@ LZT_TEST(
 
   std::vector<std::unique_ptr<std::thread>> threads;
 
-  for (int i = 0; i < num_threads; i++) {
+  for (size_t i = 0U; i < num_threads; i++) {
     threads.push_back(std::unique_ptr<std::thread>(
         new std::thread(make_resident_device_memory)));
   }
 
-  for (int i = 0; i < num_threads; i++) {
+  for (size_t i = 0U; i < num_threads; i++) {
     threads[i]->join();
   }
 }
@@ -237,12 +237,12 @@ LZT_TEST(
 
   std::vector<std::unique_ptr<std::thread>> threads;
 
-  for (int i = 0; i < num_threads; i++) {
+  for (size_t i = 0U; i < num_threads; i++) {
     threads.push_back(std::unique_ptr<std::thread>(
         new std::thread(make_resident_evict_device_memory)));
   }
 
-  for (int i = 0; i < num_threads; i++) {
+  for (size_t i = 0U; i < num_threads; i++) {
     threads[i]->join();
   }
 }
@@ -260,12 +260,12 @@ LZT_TEST(
   ze_module_handle_t module =
       lzt::create_module(device, "residency_tests_multi_thread.spv");
 
-  for (int i = 0; i < num_threads; i++) {
+  for (size_t i = 0U; i < num_threads; i++) {
     threads.push_back(std::unique_ptr<std::thread>(
         new std::thread(make_resident_evict_API, module)));
   }
 
-  for (int i = 0; i < num_threads; i++) {
+  for (size_t i = 0U; i < num_threads; i++) {
     threads[i]->join();
   }
 
@@ -285,12 +285,12 @@ LZT_TEST(
   ze_module_handle_t module =
       lzt::create_module(device, "residency_tests_multi_thread.spv");
 
-  for (int i = 0; i < num_threads; i++) {
+  for (size_t i = 0U; i < num_threads; i++) {
     threads.push_back(std::unique_ptr<std::thread>(
         new std::thread(indirect_access_Kernel, module, false)));
   }
 
-  for (int i = 0; i < num_threads; i++) {
+  for (size_t i = 0U; i < num_threads; i++) {
     threads[i]->join();
   }
 
@@ -310,12 +310,12 @@ LZT_TEST(
   ze_module_handle_t module =
       lzt::create_module(device, "residency_tests_multi_thread.spv");
 
-  for (int i = 0; i < num_threads; i++) {
+  for (size_t i = 0U; i < num_threads; i++) {
     threads.push_back(std::unique_ptr<std::thread>(
         new std::thread(indirect_access_Kernel, module, true)));
   }
 
-  for (int i = 0; i < num_threads; i++) {
+  for (size_t i = 0U; i < num_threads; i++) {
     threads[i]->join();
   }
 
@@ -352,12 +352,12 @@ LZT_TEST_F(
   lzt::zeImageCreateCommon img;
   std::vector<std::unique_ptr<std::thread>> threads;
 
-  for (int i = 0; i < num_threads; i++) {
+  for (size_t i = 0U; i < num_threads; i++) {
     threads.push_back(std::unique_ptr<std::thread>(
         new std::thread(image_make_resident_evict, img.dflt_device_image_)));
   }
 
-  for (int i = 0; i < num_threads; i++) {
+  for (size_t i = 0U; i < num_threads; i++) {
     threads[i]->join();
   }
 }

--- a/conformance_tests/core/test_multithread/src/test_device_multithread.cpp
+++ b/conformance_tests/core/test_multithread/src/test_device_multithread.cpp
@@ -87,7 +87,7 @@ void device_thread_test(ze_driver_handle_t driver) {
     auto new_cmd_q_group_properties =
         lzt::get_command_queue_group_properties(device);
     ASSERT_EQ(cmd_q_group_properties.size(), new_cmd_q_group_properties.size());
-    for (int i = 0; i < cmd_q_group_properties.size(); i++) {
+    for (size_t i = 0U; i < cmd_q_group_properties.size(); i++) {
       ASSERT_EQ(0, memcmp(&cmd_q_group_properties[i],
                           &new_cmd_q_group_properties[i],
                           sizeof(cmd_q_group_properties[i])));
@@ -101,14 +101,14 @@ LZT_TEST(zeDeviceMultithreadTests,
          GivenMultipleThreadsWhenUsingDriverAPIsThenResultsAreConsistent) {
   std::vector<std::thread *> threads;
 
-  for (int i = 0; i < num_threads; i++)
+  for (size_t i = 0U; i < num_threads; i++)
     threads.push_back(new std::thread(driver_thread_test));
 
-  for (int i = 0; i < num_threads; i++) {
+  for (size_t i = 0U; i < num_threads; i++) {
     threads[i]->join();
   }
 
-  for (int i = 0; i < num_threads; i++) {
+  for (size_t i = 0U; i < num_threads; i++) {
     delete threads[i];
   }
 }
@@ -117,14 +117,14 @@ LZT_TEST(zeDeviceMultithreadTests,
          GivenMultipleThreadsWhenUsingDeviceAPIsThenResultsAreConsistent) {
   std::vector<std::thread *> threads;
   auto driver = lzt::get_default_driver();
-  for (int i = 0; i < num_threads; i++)
+  for (size_t i = 0U; i < num_threads; i++)
     threads.push_back(new std::thread(device_thread_test, driver));
 
-  for (int i = 0; i < num_threads; i++) {
+  for (size_t i = 0U; i < num_threads; i++) {
     threads[i]->join();
   }
 
-  for (int i = 0; i < num_threads; i++) {
+  for (size_t i = 0U; i < num_threads; i++) {
     delete threads[i];
   }
 }

--- a/conformance_tests/core/test_multithread/src/test_fence_multithread.cpp
+++ b/conformance_tests/core/test_multithread/src/test_fence_multithread.cpp
@@ -33,7 +33,7 @@ void thread_func(const ze_command_queue_handle_t cq) {
 
   void *output_buffer = lzt::allocate_shared_memory(memory_size);
 
-  for (int i = 0; i < num_iterations; i++) {
+  for (size_t i = 0U; i < num_iterations; i++) {
     ze_fence_handle_t fence_ = lzt::create_fence(cq);
 
     const uint8_t pattern_base = lzt::generate_value<uint8_t>();
@@ -81,14 +81,14 @@ LZT_TEST(
 
   std::vector<std::thread *> threads;
 
-  for (int i = 0; i < num_threads; i++)
+  for (size_t i = 0U; i < num_threads; i++)
     threads.push_back(new std::thread(thread_func, cq));
 
-  for (int i = 0; i < num_threads; i++) {
+  for (size_t i = 0U; i < num_threads; i++) {
     threads[i]->join();
   }
 
-  for (int i = 0; i < num_threads; i++) {
+  for (size_t i = 0U; i < num_threads; i++) {
     delete threads[i];
   }
 

--- a/conformance_tests/core/test_multithread/src/test_image_copy_multithread.cpp
+++ b/conformance_tests/core/test_multithread/src/test_image_copy_multithread.cpp
@@ -122,12 +122,12 @@ LZT_TEST(
 
   std::vector<std::unique_ptr<std::thread>> threads;
 
-  for (int i = 0; i < num_threads; i++) {
+  for (size_t i = 0U; i < num_threads; i++) {
     threads.push_back(std::unique_ptr<std::thread>(
         new std::thread(image_create_destroy_thread)));
   }
 
-  for (int i = 0; i < num_threads; i++) {
+  for (size_t i = 0U; i < num_threads; i++) {
     threads[i]->join();
   }
 }
@@ -146,12 +146,12 @@ LZT_TEST(
   auto command_queue = lzt::create_command_queue();
   std::vector<std::unique_ptr<std::thread>> threads;
 
-  for (int i = 0; i < num_threads; i++) {
+  for (size_t i = 0U; i < num_threads; i++) {
     threads.push_back(std::unique_ptr<std::thread>(
         new std::thread(image_copy_thread, command_queue)));
   }
 
-  for (int i = 0; i < num_threads; i++) {
+  for (size_t i = 0U; i < num_threads; i++) {
     threads[i]->join();
   }
 

--- a/conformance_tests/core/test_multithread/src/test_memory_multithread.cpp
+++ b/conformance_tests/core/test_multithread/src/test_memory_multithread.cpp
@@ -274,7 +274,7 @@ LZT_TEST(
         std::make_unique<std::thread>(host_memory_create_destroy_thread);
   }
 
-  for (int i = 0; i < num_threads; i++) {
+  for (size_t i = 0U; i < num_threads; i++) {
     threads[i]->join();
   }
 }
@@ -286,12 +286,12 @@ LZT_TEST(
 
   std::array<std::unique_ptr<std::thread>, num_threads> threads;
 
-  for (uint32_t i = 0; i < num_threads; i++) {
+  for (size_t i = 0U; i < num_threads; i++) {
     threads[i] =
         std::make_unique<std::thread>(shared_memory_create_destroy_thread);
   }
 
-  for (int i = 0; i < num_threads; i++) {
+  for (size_t i = 0U; i < num_threads; i++) {
     threads[i]->join();
   }
 }
@@ -303,12 +303,12 @@ LZT_TEST(
 
   std::array<std::unique_ptr<std::thread>, num_threads> threads;
 
-  for (uint32_t i = 0; i < num_threads; i++) {
+  for (size_t i = 0U; i < num_threads; i++) {
     threads[i] =
         std::make_unique<std::thread>(device_memory_create_destroy_thread);
   }
 
-  for (int i = 0; i < num_threads; i++) {
+  for (size_t i = 0U; i < num_threads; i++) {
     threads[i]->join();
   }
 }
@@ -322,12 +322,12 @@ LZT_TEST(
 
   std::array<std::unique_ptr<std::thread>, num_threads> threads;
 
-  for (uint32_t i = 0; i < num_threads; i++) {
+  for (size_t i = 0U; i < num_threads; i++) {
     threads[i] =
         std::make_unique<std::thread>(all_memory_create_destroy_thread, cq);
   }
 
-  for (int i = 0; i < num_threads; i++) {
+  for (size_t i = 0U; i < num_threads; i++) {
     threads[i]->join();
   }
 
@@ -348,7 +348,7 @@ LZT_TEST(
         all_memory_create_destroy_submissions_thread, cq);
   }
 
-  for (int i = 0; i < num_threads; i++) {
+  for (size_t i = 0U; i < num_threads; i++) {
     threads[i]->join();
   }
 
@@ -366,7 +366,7 @@ LZT_TEST(
     threads[i] = std::make_unique<std::thread>(perform_memory_manipulation);
   }
 
-  for (int i = 0; i < num_threads; i++) {
+  for (size_t i = 0U; i < num_threads; i++) {
     threads[i]->join();
   }
 }

--- a/conformance_tests/core/test_mutable_cmdlist/src/test_mutable_cmdlist.cpp
+++ b/conformance_tests/core/test_mutable_cmdlist/src/test_mutable_cmdlist.cpp
@@ -271,11 +271,11 @@ LZT_TEST_F(
   lzt::execute_command_lists(queue, 1, &mutableCmdList, nullptr);
   lzt::synchronize(queue, std::numeric_limits<uint64_t>::max());
 
-  int32_t smallerBufferSize = groupSizeX * groupSizeY * groupSizeZ;
-  for (size_t i = 0; i < smallerBufferSize; i++) {
+  uint32_t smallerBufferSize = groupSizeX * groupSizeY * groupSizeZ;
+  for (uint32_t i = 0U; i < smallerBufferSize; i++) {
     EXPECT_EQ(inOutBuffer[i], i + i);
   }
-  for (size_t i = smallerBufferSize; i < bufferSize; i++) {
+  for (uint32_t i = smallerBufferSize; i < bufferSize; i++) {
     EXPECT_EQ(inOutBuffer[i], i);
   }
   EXPECT_EQ(globalSizesBuffer[0], groupSizeX);
@@ -295,20 +295,20 @@ LZT_TEST_F(
                     "supported";
   }
 
-  const int32_t bufferSizeX = 128;
-  const int32_t bufferSizeY = 32;
-  const int32_t bufferSizeZ = 8;
-  const int32_t bufferSize = bufferSizeX * bufferSizeY * bufferSizeZ;
-  const int32_t dimensions = 3;
+  const uint32_t bufferSizeX = 128;
+  const uint32_t bufferSizeY = 32;
+  const uint32_t bufferSizeZ = 8;
+  const uint32_t bufferSize = bufferSizeX * bufferSizeY * bufferSizeZ;
+  const uint32_t dimensions = 3;
 
   int32_t *inOutBuffer = reinterpret_cast<int32_t *>(
       lzt::allocate_host_memory(bufferSize * sizeof(int32_t)));
-  for (size_t i = 0; i < bufferSize; i++) {
+  for (uint32_t i = 0U; i < bufferSize; i++) {
     inOutBuffer[i] = 0;
   }
   int32_t *localSizesBuffer = reinterpret_cast<int32_t *>(
       lzt::allocate_host_memory(dimensions * sizeof(int32_t)));
-  for (size_t i = 0; i < dimensions; i++) {
+  for (uint32_t i = 0U; i < dimensions; i++) {
     localSizesBuffer[i] = 0;
   }
 
@@ -340,7 +340,7 @@ LZT_TEST_F(
   lzt::execute_command_lists(queue, 1, &mutableCmdList, nullptr);
   lzt::synchronize(queue, std::numeric_limits<uint64_t>::max());
 
-  for (size_t i = 0; i < bufferSize; i++) {
+  for (uint32_t i = 0U; i < bufferSize; i++) {
     EXPECT_EQ(inOutBuffer[i], i);
   }
   EXPECT_EQ(localSizesBuffer[0], groupSizeX);
@@ -361,10 +361,10 @@ LZT_TEST_F(
   lzt::execute_command_lists(queue, 1, &mutableCmdList, nullptr);
   lzt::synchronize(queue, std::numeric_limits<uint64_t>::max());
 
-  for (size_t i = 0; i < bufferSize / 2; i++) {
+  for (uint32_t i = 0U; i < bufferSize / 2; i++) {
     EXPECT_EQ(inOutBuffer[i], i + i);
   }
-  for (size_t i = bufferSize / 2; i < bufferSize; i++) {
+  for (uint32_t i = bufferSize / 2; i < bufferSize; i++) {
     EXPECT_EQ(inOutBuffer[i], i);
   }
   EXPECT_EQ(localSizesBuffer[0], groupSizeX / 2);
@@ -384,10 +384,10 @@ LZT_TEST_F(
                     "supported";
   }
 
-  const int32_t dimensions = 3;
-  int32_t *globalOffsetsBuffer = reinterpret_cast<int32_t *>(
-      lzt::allocate_host_memory(dimensions * sizeof(int32_t)));
-  for (size_t i = 0; i < dimensions; i++) {
+  const uint32_t dimensions = 3;
+  uint32_t *globalOffsetsBuffer = reinterpret_cast<uint32_t *>(
+      lzt::allocate_host_memory(dimensions * sizeof(uint32_t)));
+  for (uint32_t i = 0U; i < dimensions; i++) {
     globalOffsetsBuffer[i] = 0;
   }
 

--- a/conformance_tests/core/test_p2p/src/test_p2p.cpp
+++ b/conformance_tests/core/test_p2p/src/test_p2p.cpp
@@ -329,17 +329,17 @@ LZT_TEST_P(
   void *verification_memory2 = lzt::allocate_host_memory(mem_size_ + offset_);
 
   uint8_t *src = static_cast<uint8_t *>(initial_pattern_memory);
-  for (uint32_t i = 0; i < mem_size_ + offset_; i++) {
+  for (size_t i = 0U; i < mem_size_ + offset_; i++) {
     src[i] = i & 0xff;
   }
 
-  for (uint32_t i = 0; i < dev_instance_.size(); i++) {
+  for (size_t i = 0U; i < dev_instance_.size(); i++) {
     if (dev_instance_[i].sub_devices.size() < 2) {
       LOG_INFO << "Test cannot be run with less than 2 SubDevices";
       GTEST_SKIP();
     }
 
-    for (int j = 1; j < dev_instance_[i].sub_devices.size(); j++) {
+    for (size_t j = 1; j < dev_instance_[i].sub_devices.size(); j++) {
       if (!lzt::can_access_peer(dev_instance_[i].sub_devices[j - 1].dev,
                                 dev_instance_[i].sub_devices[j].dev)) {
         LOG_INFO
@@ -475,7 +475,7 @@ LZT_TEST_P(
     GTEST_SKIP();
   }
 
-  for (uint32_t i = 1; i < dev_instance_.size(); i++) {
+  for (size_t i = 1; i < dev_instance_.size(); i++) {
     if (!lzt::can_access_peer(dev_instance_[i - 1].dev, dev_instance_[i].dev)) {
       LOG_INFO << "FAILURE:  Device-to-Device access disabled";
       FAIL();
@@ -530,12 +530,12 @@ LZT_TEST_P(
     zeP2PTests,
     GivenP2PSubDevicesWhenSettingAndCopyingMemoryToRemoteSubDeviceThenRemoteSubDeviceGetsCorrectMemory) {
 
-  for (uint32_t i = 0; i < dev_instance_.size(); i++) {
+  for (size_t i = 0U; i < dev_instance_.size(); i++) {
     if (dev_instance_[i].sub_devices.size() < 2) {
       LOG_INFO << "Test cannot be run with less than 2 SubDevices";
       GTEST_SKIP();
     }
-    for (int j = 1; j < dev_instance_[i].sub_devices.size(); j++) {
+    for (size_t j = 1; j < dev_instance_[i].sub_devices.size(); j++) {
       if (!lzt::can_access_peer(dev_instance_[i].sub_devices[j - 1].dev,
                                 dev_instance_[i].sub_devices[j].dev)) {
         LOG_INFO
@@ -609,20 +609,20 @@ LZT_TEST_P(
 
   lzt::write_data_pattern(initial_pattern_memory, mem_size_ + offset_, 1);
 
-  std::array<size_t, num_regions> widths = {1, columns / 2, columns};
-  std::array<size_t, num_regions> heights = {1, rows / 2, rows};
-  std::array<size_t, num_regions> depths = {1, slices / 2, slices};
+  std::array<uint32_t, num_regions> widths = {1, columns / 2, columns};
+  std::array<uint32_t, num_regions> heights = {1, rows / 2, rows};
+  std::array<uint32_t, num_regions> depths = {1, slices / 2, slices};
 
   if (dev_instance_.size() < 2) {
     LOG_INFO << "Test cannot be run with less than 2 devices";
     GTEST_SKIP();
   }
 
-  for (int region = 0; region < num_regions; region++) {
+  for (size_t region = 0U; region < num_regions; region++) {
     // Define region to be copied from/to
-    auto width = widths[region];
-    auto height = heights[region];
-    auto depth = depths[region];
+    uint32_t width = widths[region];
+    uint32_t height = heights[region];
+    uint32_t depth = depths[region];
 
     ze_copy_region_t src_region;
     src_region.originX = 0;
@@ -643,7 +643,7 @@ LZT_TEST_P(
     DevInstance *ptr_dev_src;
     DevInstance *ptr_dev_dst;
 
-    for (int i = 1; i < dev_instance_.size(); i++) {
+    for (size_t i = 1; i < dev_instance_.size(); i++) {
 
       for (uint32_t d = 0; d < 2; d++) {
         size_t src_offset, dst_offset;
@@ -697,9 +697,9 @@ LZT_TEST_P(
                                              UINT64_MAX);
         lzt::reset_command_list(ptr_dev_dst->cmd_bundle.list);
 
-        for (int z = 0; z < depth; z++) {
-          for (int y = 0; y < height; y++) {
-            for (int x = 0; x < width; x++) {
+        for (uint32_t z = 0U; z < depth; z++) {
+          for (uint32_t y = 0U; y < height; y++) {
+            for (uint32_t x = 0U; x < width; x++) {
               // index calculated based on memory sized by rows * columns *
               // slices
               size_t index = z * columns * rows + y * columns + x;
@@ -731,22 +731,22 @@ LZT_TEST_P(
     GivenP2PSubDevicesWhenCopyingMemoryRegionToSubDeviceOnSameDeviceThenRemoteSubDeviceGetsCorrectMemory) {
 
   int test_count = 0;
-  const size_t num_regions = 3;
+  const uint32_t num_regions = 3;
 
   void *initial_pattern_memory = lzt::allocate_host_memory(mem_size_ + offset_);
   void *verification_memory = lzt::allocate_host_memory(mem_size_ + offset_);
 
   lzt::write_data_pattern(initial_pattern_memory, mem_size_ + offset_, 1);
 
-  std::array<size_t, num_regions> widths = {1, columns / 2, columns};
-  std::array<size_t, num_regions> heights = {1, rows / 2, rows};
-  std::array<size_t, num_regions> depths = {1, slices / 2, slices};
+  std::array<uint32_t, num_regions> widths = {1, columns / 2, columns};
+  std::array<uint32_t, num_regions> heights = {1, rows / 2, rows};
+  std::array<uint32_t, num_regions> depths = {1, slices / 2, slices};
 
-  for (int region = 0; region < num_regions; region++) {
+  for (uint32_t region = 0U; region < num_regions; region++) {
     // Define region to be copied from/to
-    auto width = widths[region];
-    auto height = heights[region];
-    auto depth = depths[region];
+    uint32_t width = widths[region];
+    uint32_t height = heights[region];
+    uint32_t depth = depths[region];
 
     ze_copy_region_t src_region;
     src_region.originX = 0;
@@ -766,7 +766,7 @@ LZT_TEST_P(
 
     DevInstance *ptr_dev_src;
     DevInstance *ptr_dev_dst;
-    for (int i = 0; i < dev_instance_.size(); i++) {
+    for (size_t i = 0U; i < dev_instance_.size(); i++) {
 
       for (uint32_t d = 0; d < 2; d++) {
         size_t src_offset, dst_offset;
@@ -784,7 +784,7 @@ LZT_TEST_P(
           GTEST_SKIP();
         }
 
-        for (int j = 1; j < dev_instance_[i].sub_devices.size(); j++) {
+        for (size_t j = 1; j < dev_instance_[i].sub_devices.size(); j++) {
 
           if (lzt::can_access_peer(dev_instance_[i].sub_devices[j - 1].dev,
                                    dev_instance_[i].sub_devices[j].dev)) {
@@ -829,9 +829,9 @@ LZT_TEST_P(
                                                UINT64_MAX);
           lzt::reset_command_list(ptr_dev_dst->cmd_bundle.list);
 
-          for (int z = 0; z < depth; z++) {
-            for (int y = 0; y < height; y++) {
-              for (int x = 0; x < width; x++) {
+          for (uint32_t z = 0U; z < depth; z++) {
+            for (uint32_t y = 0U; y < height; y++) {
+              for (uint32_t x = 0U; x < width; x++) {
                 // index calculated based on memory sized by rows * columns *
                 // slices
                 size_t index = z * columns * rows + y * columns + x;
@@ -864,27 +864,27 @@ LZT_TEST_P(
     GivenP2PSubDevicesWhenCopyingMemoryRegionToSubDeviceOnDifferentDeviceThenRemoteSubDeviceGetsCorrectMemory) {
 
   int test_count = 0;
-  const size_t num_regions = 3;
+  const uint32_t num_regions = 3;
 
   void *initial_pattern_memory = lzt::allocate_host_memory(mem_size_ + offset_);
   void *verification_memory = lzt::allocate_host_memory(mem_size_ + offset_);
 
   lzt::write_data_pattern(initial_pattern_memory, mem_size_ + offset_, 1);
 
-  std::array<size_t, num_regions> widths = {1, columns / 2, columns};
-  std::array<size_t, num_regions> heights = {1, rows / 2, rows};
-  std::array<size_t, num_regions> depths = {1, slices / 2, slices};
+  std::array<uint32_t, num_regions> widths = {1, columns / 2, columns};
+  std::array<uint32_t, num_regions> heights = {1, rows / 2, rows};
+  std::array<uint32_t, num_regions> depths = {1, slices / 2, slices};
 
   if (dev_instance_.size() < 2) {
     LOG_INFO << "Test cannot be run with less than 2 Devices";
     GTEST_SKIP();
   }
 
-  for (int region = 0; region < num_regions; region++) {
+  for (uint32_t region = 0U; region < num_regions; region++) {
     // Define region to be copied from/to
-    auto width = widths[region];
-    auto height = heights[region];
-    auto depth = depths[region];
+    uint32_t width = widths[region];
+    uint32_t height = heights[region];
+    uint32_t depth = depths[region];
 
     ze_copy_region_t src_region;
     src_region.originX = 0;
@@ -904,7 +904,7 @@ LZT_TEST_P(
 
     DevInstance *ptr_dev_src;
     DevInstance *ptr_dev_dst;
-    for (int i = 1; i < dev_instance_.size(); i++) {
+    for (size_t i = 1; i < dev_instance_.size(); i++) {
 
       for (uint32_t d = 0; d < 2; d++) {
         size_t src_offset, dst_offset;
@@ -917,8 +917,8 @@ LZT_TEST_P(
           dst_offset = offset_;
         }
 
-        for (int j = 0; j < dev_instance_[i].sub_devices.size(); j++) {
-          for (int k = 0; k < dev_instance_[i - 1].sub_devices.size(); k++) {
+        for (size_t j = 0U; j < dev_instance_[i].sub_devices.size(); j++) {
+          for (size_t k = 0U; k < dev_instance_[i - 1].sub_devices.size(); k++) {
 
             if (lzt::can_access_peer(dev_instance_[i].sub_devices[j].dev,
                                      dev_instance_[i - 1].sub_devices[k].dev)) {
@@ -963,9 +963,9 @@ LZT_TEST_P(
                                                  UINT64_MAX);
             lzt::reset_command_list(ptr_dev_dst->cmd_bundle.list);
 
-            for (int z = 0; z < depth; z++) {
-              for (int y = 0; y < height; y++) {
-                for (int x = 0; x < width; x++) {
+            for (uint32_t z = 0U; z < depth; z++) {
+              for (uint32_t y = 0U; y < height; y++) {
+                for (uint32_t x = 0U; x < width; x++) {
                   // index calculated based on memory sized by rows * columns *
                   // slices
                   size_t index = z * columns * rows + y * columns + x;
@@ -1001,14 +1001,14 @@ LZT_TEST_P(
   std::string module_name = "p2p_test_offset_pointer.spv";
   std::string func_name = "multi_device_function";
 
-  uint32_t dev_instance_size = dev_instance_.size();
+  uint32_t dev_instance_size = static_cast<uint32_t>(dev_instance_.size());
 
-  if (dev_instance_.size() < 2) {
+  if (dev_instance_size < 2) {
     LOG_INFO << "Test cannot be run with less than 2 Devices";
     GTEST_SKIP();
   }
 
-  for (uint32_t i = 1; i < dev_instance_.size(); i++) {
+  for (uint32_t i = 1; i < dev_instance_size; i++) {
     if (!lzt::can_access_peer(dev_instance_[i - 1].dev, dev_instance_[i].dev)) {
       LOG_INFO << "FAILURE:  Device-to-Device access disabled";
       FAIL();
@@ -1069,16 +1069,16 @@ LZT_TEST_P(
   std::string module_name = "p2p_test_offset_pointer.spv";
   std::string func_name = "multi_device_function";
 
-  uint32_t dev_instance_size = dev_instance_.size();
+  uint32_t dev_instance_size = static_cast<uint32_t>(dev_instance_.size());
 
-  for (uint32_t i = 0; i < dev_instance_.size(); i++) {
+  for (uint32_t i = 0U; i < dev_instance_size; i++) {
 
     if (dev_instance_[i].sub_devices.size() < 2) {
       LOG_INFO << "Test cannot be run with less than 2 SubDevices";
       GTEST_SKIP();
     }
 
-    for (int j = 1; j < dev_instance_[i].sub_devices.size(); j++) {
+    for (size_t j = 1; j < dev_instance_[i].sub_devices.size(); j++) {
       if (!lzt::can_access_peer(dev_instance_[i].sub_devices[j - 1].dev,
                                 dev_instance_[i].sub_devices[j].dev)) {
         LOG_INFO
@@ -1148,14 +1148,14 @@ LZT_TEST_P(
   std::string module_name = "p2p_test.spv";
   std::string func_name = "multi_device_function";
 
-  uint32_t dev_instance_size = dev_instance_.size();
+  uint32_t dev_instance_size = static_cast<uint32_t>(dev_instance_.size());
 
-  if (dev_instance_.size() < 2) {
+  if (dev_instance_size < 2) {
     LOG_INFO << "Test cannot be run with less than 2 Devices";
     GTEST_SKIP();
   }
 
-  for (uint32_t i = 1; i < dev_instance_.size(); i++) {
+  for (uint32_t i = 1; i < dev_instance_size; i++) {
     if (!lzt::can_access_peer(dev_instance_[i - 1].dev, dev_instance_[i].dev)) {
       LOG_INFO << "FAILURE:  Device-to-Device access disabled";
       FAIL();
@@ -1224,16 +1224,16 @@ LZT_TEST_P(
   std::string module_name = "p2p_test.spv";
   std::string func_name = "multi_device_function";
 
-  uint32_t dev_instance_size = dev_instance_.size();
+  uint32_t dev_instance_size = static_cast<uint32_t>(dev_instance_.size());
 
-  for (uint32_t i = 0; i < dev_instance_.size(); i++) {
+  for (uint32_t i = 0; i < dev_instance_size; i++) {
 
     if (dev_instance_[i].sub_devices.size() < 2) {
       LOG_INFO << "Test cannot be run with less than 2 SubDevices";
       GTEST_SKIP();
     }
 
-    for (int j = 1; j < dev_instance_[i].sub_devices.size(); j++) {
+    for (size_t j = 1; j < dev_instance_[i].sub_devices.size(); j++) {
       if (!lzt::can_access_peer(dev_instance_[i].sub_devices[j - 1].dev,
                                 dev_instance_[i].sub_devices[j].dev)) {
         LOG_INFO

--- a/conformance_tests/core/test_p2p/src/test_p2p_mem_access.cpp
+++ b/conformance_tests/core/test_p2p/src/test_p2p_mem_access.cpp
@@ -456,7 +456,7 @@ LZT_TEST_P(
   }
   kernel_name_ = std::get<0>(GetParam());
   p2p_memory_ = std::get<1>(GetParam());
-  int num_concurrent_devices = std::get<2>(GetParam());
+  uint32_t num_concurrent_devices = std::get<2>(GetParam());
 
   uint32_t base_index = 0;
   uint32_t concurrent_index = 0;
@@ -542,7 +542,7 @@ LZT_TEST_P(
 
   kernel_name_ = std::get<0>(GetParam());
   p2p_memory_ = std::get<1>(GetParam());
-  int num_concurrent_devices = std::get<2>(GetParam());
+  uint32_t num_concurrent_devices = std::get<2>(GetParam());
 
   uint32_t base_index = 0;
   uint32_t concurrent_index = 0;

--- a/conformance_tests/core/test_residency/src/test_residency.cpp
+++ b/conformance_tests/core/test_residency/src/test_residency.cpp
@@ -112,7 +112,7 @@ LZT_TEST_F(
         sizeof(node), 1, device_flags, host_flags, device, context));
     data->value = 0;
     node *temp = data;
-    for (int i = 0; i < size; i++) {
+    for (size_t i = 0U; i < size; i++) {
       temp->next = static_cast<node *>(lzt::allocate_shared_memory(
           sizeof(node), 1, device_flags, host_flags, device, context));
       temp = temp->next;
@@ -132,7 +132,7 @@ LZT_TEST_F(
 
     temp = data->next;
     node *temp2;
-    for (int i = 0; i < size; i++) {
+    for (size_t i = 0U; i < size; i++) {
       temp2 = temp->next;
       lzt::make_memory_resident(device, temp, sizeof(node));
       temp = temp2;
@@ -142,7 +142,7 @@ LZT_TEST_F(
     lzt::synchronize(command_queue, UINT64_MAX);
 
     temp = data->next;
-    for (int i = 0; i < size; i++) {
+    for (size_t i = 0U; i < size; i++) {
       lzt::evict_memory(device, temp, sizeof(node));
       temp = temp->next;
     }
@@ -150,7 +150,7 @@ LZT_TEST_F(
     // cleanup
     temp = data;
     // total of size elements linked *after* initial element
-    for (int i = 0; i < size + 1; i++) {
+    for (size_t i = 0U; i < size + 1; i++) {
       // the kernel increments each node's value by 1
       ASSERT_EQ(temp->value, i + 1);
 
@@ -203,7 +203,7 @@ LZT_TEST_F(
     data->value = 0;
     node *temp = data;
 
-    for (int i = 0; i < size; i++) {
+    for (size_t i = 0U; i < size; i++) {
       temp->next = new node;
 
       temp = temp->next;
@@ -223,7 +223,7 @@ LZT_TEST_F(
 
     temp = data->next;
     node *temp2;
-    for (int i = 0; i < size; i++) {
+    for (size_t i = 0U; i < size; i++) {
       temp2 = temp->next;
       lzt::make_memory_resident(device, temp, sizeof(node));
       temp = temp2;
@@ -232,7 +232,7 @@ LZT_TEST_F(
     lzt::synchronize(command_queue, UINT64_MAX);
 
     temp = data->next;
-    for (int i = 0; i < size; i++) {
+    for (size_t i = 0U; i < size; i++) {
       lzt::evict_memory(device, temp, sizeof(node));
       temp = temp->next;
     }
@@ -240,7 +240,7 @@ LZT_TEST_F(
     // cleanup
     temp = data;
     // total of size elements linked *after* initial element
-    for (int i = 0; i < size + 1; i++) {
+    for (size_t i = 0U; i < size + 1; i++) {
       // kernel should increment node's value by 1
       ASSERT_EQ(temp->value, i + 1);
 
@@ -288,7 +288,7 @@ void RunGivenSharedMemoryWhenMakingMemoryResidentUsingKernelFlagTest(
         sizeof(node), 1, device_flags, host_flags, device, context));
     data->value = 0;
     node *temp = data;
-    for (int i = 0; i < size; i++) {
+    for (size_t i = 0U; i < size; i++) {
       temp->next = static_cast<node *>(lzt::allocate_shared_memory(
           sizeof(node), 1, device_flags, host_flags, device, context));
       temp = temp->next;
@@ -313,7 +313,7 @@ void RunGivenSharedMemoryWhenMakingMemoryResidentUsingKernelFlagTest(
     // cleanup
     temp = data;
     node *temp2;
-    for (int i = 0; i < size + 1; i++) {
+    for (size_t i = 0U; i < size + 1; i++) {
       // kernel should increment each node's value by 1
       ASSERT_EQ(temp->value, i + 1);
 
@@ -376,7 +376,7 @@ void RunGivenSharedSystemMemoryWhenMakingMemoryResidentUsingKernelFlagTest(
     node *data = new node;
     data->value = 0;
     node *temp = data;
-    for (int i = 0; i < size; i++) {
+    for (size_t i = 0U; i < size; i++) {
       temp->next = new node;
 
       temp = temp->next;
@@ -399,7 +399,7 @@ void RunGivenSharedSystemMemoryWhenMakingMemoryResidentUsingKernelFlagTest(
     temp = data;
     node *temp2;
     // total of size elements linked *after* initial element
-    for (int i = 0; i < size + 1; i++) {
+    for (size_t i = 0U; i < size + 1; i++) {
       // kernel should increment node's value by 1
       ASSERT_EQ(temp->value, i + 1);
 

--- a/conformance_tests/core/test_usm/src/test_usm.cpp
+++ b/conformance_tests/core/test_usm/src/test_usm.cpp
@@ -166,7 +166,7 @@ public:
     }
     // For each combination of memory, iterate through all the valid devices
 
-    for (int i = 0; i < driver_info->number_device_handles; i++) {
+    for (uint32_t i = 0U; i < driver_info->number_device_handles; i++) {
       device_in_driver_index = i;
 
       ze_device_handle_t device_handle =
@@ -418,7 +418,7 @@ public:
 
     // For each combination of memory, iterate through all the valid devices
 
-    for (int i = 0; i < driver_info->number_device_handles; i++) {
+    for (uint32_t i = 0U; i < driver_info->number_device_handles; i++) {
       device_in_driver_index = i;
 
       ze_device_handle_t device_handle =
@@ -681,7 +681,7 @@ test_multi_device_shared_memory(std::vector<ze_device_handle_t> devices,
                     }),
                 devices.end());
 
-  for (int i = 0; i < devices.size(); i++) {
+  for (size_t i = 0U; i < devices.size(); i++) {
     if (!lzt::can_access_peer(devices[0], devices[i])) {
       LOG_WARNING << "P2P Access not supported between devices, skipping test";
       GTEST_SKIP();
@@ -699,7 +699,7 @@ test_multi_device_shared_memory(std::vector<ze_device_handle_t> devices,
   const int pattern_size = 1;
   uint8_t pattern = 0x01;
 
-  for (int i = 0; i < devices.size(); i++) {
+  for (size_t i = 0U; i < devices.size(); i++) {
     auto cmd_bundle = lzt::create_command_bundle(devices[i], is_immediate);
     lzt::append_memory_fill(cmd_bundle.list, memory, &pattern, pattern_size,
                             memory_size, nullptr);
@@ -707,7 +707,7 @@ test_multi_device_shared_memory(std::vector<ze_device_handle_t> devices,
     lzt::execute_and_sync_command_bundle(cmd_bundle, UINT64_MAX);
     lzt::destroy_command_bundle(cmd_bundle);
 
-    for (int j = 0; j < memory_size; j++) {
+    for (size_t j = 0U; j < memory_size; j++) {
       ASSERT_EQ(static_cast<uint8_t *>(memory)[j], pattern);
     }
     pattern++;

--- a/conformance_tests/sysman/test_sysman_device/src/test_sysman_device.cpp
+++ b/conformance_tests/sysman/test_sysman_device/src/test_sysman_device.cpp
@@ -394,7 +394,7 @@ LZT_TEST_F(
     if (processes.size() > 0) {
       for (auto process : processes) {
         EXPECT_GT(process.processId, 0u);
-        if (process.processId == pid) {
+        if (process.processId == static_cast<uint32_t>(pid)) {
           pid_found = 1;
         }
       }
@@ -503,10 +503,10 @@ static std::vector<float>
 perform_matrix_multiplication_on_cpu(std::vector<float> a, std::vector<float> b,
                                      uint32_t n) {
   std::vector<float> c_cpu(n * n, 0);
-  for (int i = 0; i < n; i++) {
-    for (int j = 0; j < n; j++) {
+  for (uint32_t i = 0U; i < n; i++) {
+    for (uint32_t j = 0U; j < n; j++) {
       float sum = 0;
-      for (int kl = 0; kl < n; kl++) {
+      for (uint32_t kl = 0U; kl < n; kl++) {
         sum += a[i * n + kl] * b[kl * n + j];
       }
       c_cpu[i * n + j] = sum;
@@ -516,7 +516,7 @@ perform_matrix_multiplication_on_cpu(std::vector<float> a, std::vector<float> b,
 }
 
 static void compare_results(std::vector<float> c, std::vector<float> c_cpu) {
-  for (int i = 0; i < c.size(); i++) {
+  for (size_t i = 0U; i < c.size(); i++) {
     if (c[i] != c_cpu[i]) {
       EXPECT_EQ(c[i], c_cpu[i]);
     }
@@ -529,7 +529,7 @@ bool is_compute_engine_used(int pid, zes_device_handle_t device) {
   auto processes = lzt::get_processes_state(device, count);
 
   for (const auto &process : processes) {
-    if (process.processId == pid &&
+    if (process.processId == static_cast<uint32_t>(pid) &&
         process.engines == ZES_ENGINE_TYPE_FLAG_COMPUTE) {
       return true;
     }
@@ -797,15 +797,15 @@ LZT_TEST_F(
   const char *valueString = std::getenv("LZT_SYSMAN_DEVICE_TEST_ITERATIONS");
   uint32_t number_iterations = 2;
   if (valueString != nullptr) {
-    auto _value = atoi(valueString);
-    number_iterations = _value < 0 ? number_iterations : std::min(_value, 300);
+    uint32_t _value = static_cast<uint32_t>(atoi(valueString));
+    number_iterations = _value < 0 ? number_iterations : std::min(_value, 300U);
     if (number_iterations != _value) {
       LOG_WARNING << "Number of iterations is capped at 300\n";
     }
   }
 
   for (auto device : devices) {
-    for (int i = 0; i < number_iterations; i++) {
+    for (uint32_t i = 0U; i < number_iterations; i++) {
       // Perform workload execution before reset
 #ifdef USE_ZESINIT
       auto sysman_device_properties = lzt::get_sysman_device_properties(device);

--- a/conformance_tests/sysman/test_sysman_memory/src/test_sysman_memory.cpp
+++ b/conformance_tests/sysman/test_sysman_memory/src/test_sysman_memory.cpp
@@ -408,7 +408,7 @@ LZT_TEST_F(
 
     EXPECT_EQ(ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY, result);
 
-    for (int i = 0; i < alloc_list.size(); i++) {
+    for (size_t i = 0U; i < alloc_list.size(); i++) {
       result = zeMemFree(lzt::get_default_context(), alloc_list[i]);
       EXPECT_ZE_RESULT_SUCCESS(result);
     }

--- a/conformance_tests/sysman/test_sysman_power/src/test_sysman_power.cpp
+++ b/conformance_tests/sysman/test_sysman_power/src/test_sysman_power.cpp
@@ -616,7 +616,7 @@ LZT_TEST_F(
             power_limits_descriptors_initial; // preserve initial power limit
                                               // descriptors for restoration
                                               // later
-        for (int i = 0; i < power_limits_descriptors.size(); i++) {
+        for (size_t i = 0U; i < power_limits_descriptors.size(); i++) {
           power_limits_descriptors[i] = {
               ZES_STRUCTURE_TYPE_POWER_LIMIT_EXT_DESC, nullptr};
           power_limits_descriptors_initial.push_back(
@@ -716,7 +716,7 @@ LZT_TEST_F(
             power_limits_descriptors_initial; // preserve initial power limit
                                               // descriptors for restoration
                                               // later
-        for (int i = 0; i < power_limits_descriptors.size(); i++) {
+        for (size_t i = 0U; i < power_limits_descriptors.size(); i++) {
           power_limits_descriptors_initial.push_back(
               power_limits_descriptors[i]);
 
@@ -804,7 +804,7 @@ LZT_TEST_F(
                                               // descriptors for restoration
                                               // later
 
-        for (int i = 0; i < power_limits_descriptors.size(); i++) {
+        for (size_t i = 0U; i < power_limits_descriptors.size(); i++) {
           power_limits_descriptors_initial.push_back(
               power_limits_descriptors[i]);
           if (power_limits_descriptors[i].level == ZES_POWER_LEVEL_BURST) {
@@ -890,7 +890,7 @@ LZT_TEST_F(
                                               // descriptors for restoration
                                               // later
 
-        for (int i = 0; i < power_limits_descriptors.size(); i++) {
+        for (size_t i = 0U; i < power_limits_descriptors.size(); i++) {
           power_limits_descriptors_initial.push_back(
               power_limits_descriptors[i]);
           if (power_limits_descriptors[i].level ==
@@ -1018,7 +1018,7 @@ LZT_TEST_F(
           continue;
         }
         EXPECT_ZE_RESULT_SUCCESS(status);
-        for (int i = 0; i < power_limits_descriptors.size(); i++) {
+        for (size_t i = 0U; i < power_limits_descriptors.size(); i++) {
           if (power_limits_descriptors[i].level == ZES_POWER_LEVEL_SUSTAINED) {
             sustained_limit_available = true;
             power_sustained_Max = power_limits_descriptors[i];
@@ -1116,7 +1116,7 @@ LZT_TEST_F(
           continue;
         }
         EXPECT_ZE_RESULT_SUCCESS(status);
-        for (int i = 0; i < power_limits_descriptors.size(); i++) {
+        for (size_t i = 0U; i < power_limits_descriptors.size(); i++) {
           zes_power_limit_ext_desc_t power_peak_initial = {};
           zes_power_limit_ext_desc_t power_peak_Max = {};
           zes_power_limit_ext_desc_t power_peak_getMax = {};

--- a/conformance_tests/tools/debug/src/test_debug.cpp
+++ b/conformance_tests/tools/debug/src/test_debug.cpp
@@ -878,13 +878,13 @@ void verify_single_application_host_thread(
   ASSERT_EQ(debug_event.type, ZET_DEBUG_EVENT_TYPE_PROCESS_ENTRY);
 
   LOG_INFO << "[Debugger] Waiting for application module load debug events";
-  for (int i = 0; i < num_expected_module_events; i++) {
+  for (uint32_t i = 0; i < num_expected_module_events; i++) {
     lzt::debug_read_event(debug_session, debug_event, eventsTimeoutMS, false);
     ASSERT_EQ(debug_event.type, ZET_DEBUG_EVENT_TYPE_MODULE_LOAD);
     lzt::debug_ack_event(debug_session, &debug_event);
   }
   LOG_INFO << "[Debugger] Waiting for application module load debug events";
-  for (int i = 0; i < num_expected_module_events; i++) {
+  for (uint32_t i = 0; i < num_expected_module_events; i++) {
     lzt::debug_read_event(debug_session, debug_event, eventsTimeoutMS, false);
     ASSERT_EQ(debug_event.type, ZET_DEBUG_EVENT_TYPE_MODULE_UNLOAD);
   }
@@ -905,7 +905,7 @@ void read_and_verify_events_multithreaded_app(
 
   auto num_application_host_threads_to_verify = 2;
   auto broken = false;
-  for (int i = 0; i < (num_expected_module_events * 2 * 2); i++) {
+  for (uint32_t i = 0; i < (num_expected_module_events * 2 * 2); i++) {
     // module load and unload events can be interleaved if threads run
     // concurrently if threads run sequentially we will expect a process exit
     // event in this loop
@@ -1298,7 +1298,7 @@ void zetDebugReadWriteRegistersTest::run_read_write_registers_test(
       int regSetNumber = 1;
 
       for (auto &register_set : register_set_properties) {
-        auto buffer_size = register_set.byteSize * register_set.count;
+        uint32_t buffer_size = register_set.byteSize * register_set.count;
         void *buffer = lzt::allocate_host_memory(register_set.byteSize *
                                                  register_set.count);
         void *buffer_copy = lzt::allocate_host_memory(register_set.byteSize *
@@ -1334,7 +1334,7 @@ void zetDebugReadWriteRegistersTest::run_read_write_registers_test(
                                       register_set.type, 0, register_set.count,
                                       buffer);
 
-            for (int i = 0; i < buffer_size; i++) {
+            for (uint32_t i = 0U; i < buffer_size; i++) {
               if (static_cast<char>(0xaa) != static_cast<char *>(buffer)[i]) {
                 delete[] kernel_buffer;
                 auto found_val = static_cast<char *>(buffer)[i];

--- a/conformance_tests/tools/debug/src/test_debug_helper.cpp
+++ b/conformance_tests/tools/debug/src/test_debug_helper.cpp
@@ -40,7 +40,7 @@ void basic(ze_context_handle_t context, ze_device_handle_t device,
 
   auto kernel = lzt::create_function(module, "debug_add_constant_2");
 
-  auto size = 256;
+  size_t size = 256;
   ze_kernel_properties_t kernel_properties = {
       ZE_STRUCTURE_TYPE_KERNEL_PROPERTIES, nullptr};
   EXPECT_ZE_RESULT_SUCCESS(zeKernelGetProperties(kernel, &kernel_properties));
@@ -131,7 +131,7 @@ void attach_after_module_created_test(ze_context_handle_t context,
   LOG_INFO << "[Application] Creating kernel";
   auto kernel = lzt::create_function(module, "debug_add_constant_2");
 
-  auto size = 8192;
+  size_t size = 8192;
   ze_kernel_properties_t kernel_properties = {
       ZE_STRUCTURE_TYPE_KERNEL_PROPERTIES, nullptr};
   EXPECT_ZE_RESULT_SUCCESS(zeKernelGetProperties(kernel, &kernel_properties));
@@ -225,7 +225,7 @@ void attach_after_module_destroyed_test(ze_context_handle_t context,
 
   auto kernel = lzt::create_function(module, "debug_add_constant_2");
 
-  auto size = 8192;
+  size_t size = 8192;
   ze_kernel_properties_t kernel_properties = {
       ZE_STRUCTURE_TYPE_KERNEL_PROPERTIES, nullptr};
   EXPECT_ZE_RESULT_SUCCESS(zeKernelGetProperties(kernel, &kernel_properties));
@@ -333,7 +333,7 @@ void multiple_modules_created_test(ze_context_handle_t context,
   lzt::append_launch_function(command_list, kernel2, &group_count, nullptr, 0,
                               nullptr);
 
-  auto size = 8192;
+  size_t size = 8192;
   ze_kernel_properties_t kernel_properties = {
       ZE_STRUCTURE_TYPE_KERNEL_PROPERTIES, nullptr};
   EXPECT_ZE_RESULT_SUCCESS(zeKernelGetProperties(kernel, &kernel_properties));

--- a/conformance_tests/tools/debug/src/test_debug_utils.cpp
+++ b/conformance_tests/tools/debug/src/test_debug_utils.cpp
@@ -70,7 +70,7 @@ bool check_events_unordered(const zet_debug_session_handle_t &debug_session,
 
   zet_debug_event_t debugEvent;
 
-  for (int i = 0; i < eventTypes.size(); i++) {
+  for (size_t i = 0U; i < eventTypes.size(); i++) {
     lzt::debug_read_event(debug_session, debugEvent, eventsTimeoutMS, false);
 
     // note: this should be modified if eventTypes contains duplicates
@@ -380,7 +380,7 @@ void readWriteModuleMemory(const zet_debug_session_handle_t &debug_session,
     EXPECT_EQ(elf_buffer[2], 'L');
     EXPECT_EQ(elf_buffer[3], 'F');
 
-    for (int i = 0; i < elf_size; i++) {
+    for (size_t i = 0U; i < elf_size; i++) {
       if (elf_buffer[i] != 0xaa) {
         read_success = true;
       }
@@ -392,7 +392,7 @@ void readWriteModuleMemory(const zet_debug_session_handle_t &debug_session,
     desc.address += offset; // add intentional missalignment
     lzt::debug_read_memory(debug_session, thread, desc, elf_size - offset,
                            elf_buffer);
-    for (int i = 0; i < elf_size; i++) {
+    for (size_t i = 0U; i < elf_size; i++) {
       if (elf_buffer[i] != 0xaa) {
         read_success = true;
       }
@@ -417,7 +417,7 @@ int get_numCQs_per_ordinal(ze_device_handle_t &device,
       numQueueGroups);
   queueProperties = lzt::get_command_queue_group_properties(device);
 
-  for (int i = 0; i < numQueueGroups; i++) {
+  for (uint32_t i = 0U; i < numQueueGroups; i++) {
     ordinalCQs[i] = queueProperties[i].numQueues;
 
     LOG_DEBUG << "ordinal: " << i << " CQs: " << queueProperties[i].numQueues;

--- a/conformance_tests/tools/metrics/src/test_metric.cpp
+++ b/conformance_tests/tools/metrics/src/test_metric.cpp
@@ -1658,7 +1658,7 @@ LZT_TEST_F(
       std::vector<uint8_t> rawData;
       ze_result_t result;
       constexpr uint32_t maxAttempts = 6;
-      uint64_t timeForNextIterationSec = 10;
+      time_t timeForNextIterationSec = 10;
 
       for (uint32_t i = 0; i < maxAttempts; i++) {
         // Busy wait before trying to read to increase chanceof  buffer overflow

--- a/conformance_tests/tools/metrics/src/test_metric_tracer.cpp
+++ b/conformance_tests/tools/metrics/src/test_metric_tracer.cpp
@@ -82,8 +82,8 @@ LZT_TEST_F(
 
     ASSERT_GT(device_with_metric_group_handles
                   .activatable_metric_group_handle_list.size(),
-              0u);
-    for (int32_t i = 0; i < device_with_metric_group_handles
+              0U);
+    for (size_t i = 0U; i < device_with_metric_group_handles
                                 .activatable_metric_group_handle_list.size();
          i++) {
 
@@ -701,8 +701,8 @@ LZT_TEST_F(
 
     ASSERT_GT(device_with_metric_group_handles
                   .activatable_metric_group_handle_list.size(),
-              0u);
-    for (int32_t i = 0; i < device_with_metric_group_handles
+              0U);
+    for (size_t i = 0U; i < device_with_metric_group_handles
                                 .activatable_metric_group_handle_list.size();
          i++) {
 
@@ -748,8 +748,8 @@ LZT_TEST_F(
 
     ASSERT_GT(device_with_metric_group_handles
                   .activatable_metric_group_handle_list.size(),
-              0u);
-    for (int32_t i = 0; i < device_with_metric_group_handles
+              0U);
+    for (size_t i = 0U; i < device_with_metric_group_handles
                                 .activatable_metric_group_handle_list.size();
          i++) {
 
@@ -893,8 +893,8 @@ void run_metric_tracer_read_test(
 
     ASSERT_GT(device_with_metric_group_handles
                   .activatable_metric_group_handle_list.size(),
-              0u);
-    for (int32_t i = 0; i < device_with_metric_group_handles
+              0U);
+    for (size_t i = 0U; i < device_with_metric_group_handles
                                 .activatable_metric_group_handle_list.size();
          i++) {
 
@@ -1123,8 +1123,8 @@ LZT_TEST_F(zetMetricTracerTest,
            "value "
            "for the count of decodable metrics";
 
-    ASSERT_GT(num_decodable_metrics, 0u);
-    for (int i = 0; i < num_decodable_metrics; i++) {
+    ASSERT_GT(num_decodable_metrics, 0U);
+    for (uint32_t i = 0U; i < num_decodable_metrics; i++) {
       bool valid_type;
       zet_metric_properties_t metric_properties;
       lzt::get_metric_properties(metric_handles[i], &metric_properties);
@@ -1169,8 +1169,8 @@ LZT_TEST_F(
 
     ASSERT_GT(device_with_metric_group_handles
                   .activatable_metric_group_handle_list.size(),
-              0u);
-    for (int32_t i = 0; i < device_with_metric_group_handles
+              0U);
+    for (size_t i = 0U; i < device_with_metric_group_handles
                                 .activatable_metric_group_handle_list.size();
          i++) {
 

--- a/negative_tests/core/test_handle_tracking/src/test_handle_tracking_errors.cpp
+++ b/negative_tests/core/test_handle_tracking/src/test_handle_tracking_errors.cpp
@@ -185,7 +185,7 @@ LZT_TEST_F(
             zeKernelCreate(invalid_module, &kernel_desc, &kernel));
   ASSERT_ZE_RESULT_SUCCESS(zeKernelCreate(module, &kernel_desc, &kernel));
 
-  auto size = 8192;
+  size_t size = 8192;
   ze_kernel_properties_t kernel_properties = {
       ZE_STRUCTURE_TYPE_KERNEL_PROPERTIES, nullptr};
   ASSERT_EQ(ZE_RESULT_ERROR_INVALID_NULL_HANDLE,
@@ -217,7 +217,7 @@ LZT_TEST_F(
       zeMemAllocDevice(context, &device_desc, size, 1, device, &buffer_b));
 
   std::memset(buffer_a, 0, size);
-  for (size_t i = 0; i < size; i++) {
+  for (size_t i = 0U; i < size; i++) {
     static_cast<uint8_t *>(buffer_a)[i] = (i & 0xFF);
   }
 
@@ -324,7 +324,7 @@ LZT_TEST_F(
 
   // validation
   LOG_DEBUG << "Validating results";
-  for (size_t i = 0; i < size; i++) {
+  for (size_t i = 0U; i < size; i++) {
     EXPECT_EQ(static_cast<uint8_t *>(buffer_a)[i],
               static_cast<uint8_t>((i & 0xFF) + addval));
     if (::testing::Test::HasFailure()) {

--- a/perf_tests/common/src/ze_app.cpp
+++ b/perf_tests/common/src/ze_app.cpp
@@ -448,7 +448,7 @@ void ZeApp::initCountDevices(const uint32_t count) {
 
   if (_module_path.size() != 0) {
     _modules.resize(device_count);
-    for (int i = 0; i < device_count; i++) {
+    for (uint32_t i = 0U; i < device_count; i++) {
       moduleCreate(_devices[i], &_modules[i]);
     }
   }
@@ -463,7 +463,7 @@ uint32_t ZeApp::allDevicesInit(void) {
 
 void ZeApp::cleanupDevices(void) {
   if (_module_path.size() != 0) {
-    for (int i = 0; i < _devices.size(); i++) {
+    for (size_t i = 0U; i < _devices.size(); i++) {
       moduleDestroy(_modules[i]);
     }
   }

--- a/perf_tests/ze_bandwidth/src/ze_bandwidth.cpp
+++ b/perf_tests/ze_bandwidth/src/ze_bandwidth.cpp
@@ -434,7 +434,7 @@ void ZeBandwidth::test_host2device(void) {
   for (auto size : transfer_size) {
     long double total_time_nsec = 0;
     std::vector<long double> device_times_nsec(benchmark->_devices.size());
-    for (int i = 0; i < device_times_nsec.size(); i++) {
+    for (size_t i = 0U; i < device_times_nsec.size(); i++) {
       device_times_nsec[i] = 0;
     }
 
@@ -484,7 +484,7 @@ void ZeBandwidth::test_device2host(void) {
   for (auto size : transfer_size) {
     long double total_time_nsec = 0;
     std::vector<long double> device_times_nsec(benchmark->_devices.size());
-    for (int i = 0; i < device_times_nsec.size(); i++) {
+    for (size_t i = 0U; i < device_times_nsec.size(); i++) {
       device_times_nsec[i] = 0;
     }
 
@@ -536,7 +536,7 @@ void ZeBandwidth::test_bidir(void) {
   for (auto size : transfer_size) {
     long double total_time_nsec = 0;
     std::vector<long double> device_times_nsec(benchmark->_devices.size());
-    for (int i = 0; i < device_times_nsec.size(); i++) {
+    for (size_t i = 0U; i < device_times_nsec.size(); i++) {
       device_times_nsec[i] = 0;
     }
 

--- a/perf_tests/ze_image_copy/src/options.cpp
+++ b/perf_tests/ze_image_copy/src/options.cpp
@@ -78,7 +78,7 @@ int ZeImageCopy::parse_command_line(int argc, char **argv) {
     std::cout << "unknown format layout" << std::endl;
     std::cout << desc << std::endl;
     return 1;
-  } else if (Imageflags == -1) {
+  } else if (Imageflags == -1U) {
     std::cout << "unknown image flags" << std::endl;
     std::cout << desc << std::endl;
     return 1;

--- a/perf_tests/ze_image_copy/src/ze_image_copy.cpp
+++ b/perf_tests/ze_image_copy/src/ze_image_copy.cpp
@@ -92,7 +92,7 @@ void ZeImageCopy::test_initialize(void) {
   hdevice_event = new ze_event_handle_t[num_wait_events];
   event_pool = benchmark->create_event_pool(num_wait_events,
                                             ZE_EVENT_POOL_FLAG_HOST_VISIBLE);
-  for (int i = 0; i < num_wait_events; i++) {
+  for (uint32_t i = 0U; i < num_wait_events; i++) {
     benchmark->create_event(event_pool, hdevice_event[i], i);
     zeEventHostReset(hdevice_event[i]);
   }
@@ -108,7 +108,7 @@ void ZeImageCopy::test_cleanup(void) {
 #endif
   benchmark->imageDestroy(this->image);
   image = nullptr;
-  for (int i = 0; i < num_wait_events; i++)
+  for (uint32_t i = 0U; i < num_wait_events; i++)
     benchmark->destroy_event(hdevice_event[i]);
   benchmark->destroy_event_pool(this->event_pool);
   event_pool = nullptr;
@@ -116,7 +116,7 @@ void ZeImageCopy::test_cleanup(void) {
 }
 
 void ZeImageCopy::reset_all_events(void) {
-  for (int i = 0; i < num_wait_events; i++) {
+  for (uint32_t i = 0U; i < num_wait_events; i++) {
     zeEventHostReset(hdevice_event[i]);
   }
 }
@@ -148,13 +148,13 @@ void ZeImageCopy::measureHost2Device2Host() {
   benchmark->commandListClose(command_list);
 
   /* Warm up */
-  for (int i = 0; i < warm_up_iterations; i++) {
+  for (uint32_t i = 0U; i < warm_up_iterations; i++) {
     benchmark->commandQueueExecuteCommandList(command_queue, 1, &command_list);
     benchmark->commandQueueSynchronize(command_queue);
   }
 
   // Measure the bandwidth of copy from host to device to host only
-  for (int i = 0; i < num_iterations; i++) {
+  for (uint32_t i = 0U; i < num_iterations; i++) {
 
     timer.start();
 
@@ -191,7 +191,7 @@ void ZeImageCopy::measureParallelHost2Device() {
 
   // Copy from srcBuffer->Image->dstBuffer, so at the end dstBuffer = srcBuffer
   benchmark->commandListReset(command_list_a);
-  for (int i = 0; i < num_image_copies; i++) {
+  for (uint32_t i = 0U; i < num_image_copies; i++) {
     benchmark->commandListAppendImageCopyFromMemory(command_list_a, image,
                                                     srcBuffer, &this->region);
   }
@@ -210,7 +210,7 @@ void ZeImageCopy::measureParallelHost2Device() {
   benchmark->commandQueueExecuteCommandList(command_queue, 1, &command_list_b);
   benchmark->commandQueueSynchronize(command_queue);
 
-  for (int i = 0; i < num_iterations; i++) {
+  for (uint32_t i = 0U; i < num_iterations; i++) {
 
     // Measure the bandwidth of copy from host to device only
     timer.start();
@@ -263,7 +263,7 @@ void ZeImageCopy::measureParallelDevice2Host() {
   // commandListReset to make sure resetting the command_list_b from previous
   // operations on host2device
   benchmark->commandListReset(command_list_b);
-  for (int i = 0; i < num_image_copies; i++) {
+  for (uint32_t i = 0U; i < num_image_copies; i++) {
     benchmark->commandListAppendImageCopyToMemory(command_list_b, dstBuffer,
                                                   image, &this->region);
   }
@@ -276,7 +276,7 @@ void ZeImageCopy::measureParallelDevice2Host() {
   benchmark->commandQueueExecuteCommandList(command_queue, 1, &command_list_b);
   benchmark->commandQueueSynchronize(command_queue);
 
-  for (int i = 0; i < num_iterations; i++) {
+  for (uint32_t i = 0U; i < num_iterations; i++) {
 
     // measure the bandwidth of copy from device to host only
     timer.start();
@@ -325,7 +325,7 @@ void ZeImageCopy::measureSerialHost2Device() {
   ze_event_handle_t *first_event = &hdevice_event[0];
   ze_event_handle_t *last_event = &hdevice_event[num_wait_events - 1];
   benchmark->commandListAppendWaitOnEvents(command_list_a, 1, first_event);
-  for (int i = 0; i < num_image_copies; i++) {
+  for (uint32_t i = 0U; i < num_image_copies; i++) {
     benchmark->commandListAppendImageCopyFromMemory(
         command_list_a, image, srcBuffer, &this->region,
         hdevice_event[i + 1] // Signal this event upon image copy completion
@@ -344,7 +344,7 @@ void ZeImageCopy::measureSerialHost2Device() {
   benchmark->commandListClose(command_list_b);
 
   // Warm up
-  for (int j = 0; j < warm_up_iterations; j++) {
+  for (uint32_t i = 0U; i < warm_up_iterations; i++) {
     // Launch all command queued. They will wait to be executed until after
     // an event is signaled.
     benchmark->commandQueueExecuteCommandList(command_queue, 1,
@@ -359,7 +359,7 @@ void ZeImageCopy::measureSerialHost2Device() {
 
   // Measure the bandwidth of copy from host to device only
   total_time_usec = 0;
-  for (int j = 0; j < num_iterations; j++) {
+  for (uint32_t i = 0U; i < num_iterations; i++) {
     benchmark->commandQueueExecuteCommandList(command_queue, 1,
                                               &command_list_a);
     timer.start();
@@ -420,7 +420,7 @@ void ZeImageCopy::measureSerialDevice2Host() {
   ze_event_handle_t *first_event = &hdevice_event[0];
   ze_event_handle_t *last_event = &hdevice_event[num_wait_events - 1];
   benchmark->commandListAppendWaitOnEvents(command_list_b, 1, first_event);
-  for (int i = 0; i < num_image_copies; i++) {
+  for (uint32_t i = 0U; i < num_image_copies; i++) {
     benchmark->commandListAppendImageCopyToMemory(
         command_list_b, dstBuffer, image, &this->region,
         hdevice_event[i + 1] // Signal this event upon image copy completion
@@ -433,7 +433,7 @@ void ZeImageCopy::measureSerialDevice2Host() {
   benchmark->commandListClose(command_list_b);
 
   // Warm up
-  for (int i = 0; i < warm_up_iterations; i++) {
+  for (uint32_t i = 0U; i < warm_up_iterations; i++) {
     // Launch all command queued. They will wait to be executed until after
     // an event is signaled.
     benchmark->commandQueueExecuteCommandList(command_queue, 1,
@@ -448,7 +448,7 @@ void ZeImageCopy::measureSerialDevice2Host() {
 
   // Measure the bandwidth of copy from device to host only
   total_time_usec = 0;
-  for (int i = 0; i < num_iterations; i++) {
+  for (uint32_t i = 0U; i < num_iterations; i++) {
     // Measure the bandwidth of copy from device to host only
     benchmark->commandQueueExecuteCommandList(command_queue, 1,
                                               &command_list_b);

--- a/perf_tests/ze_peak/src/dp_compute.cpp
+++ b/perf_tests/ze_peak/src/dp_compute.cpp
@@ -129,7 +129,7 @@ std::vector<long double> ZePeak::ze_peak_dp_compute(L0Context &context) {
     std::cout << "device output buffer allocated\n";
 
   if (context.sub_device_count) {
-    for (auto i = 0; i < context.sub_device_count; i++) {
+    for (uint32_t i = 0U; i < context.sub_device_count; i++) {
       result = zeCommandListAppendMemoryCopy(context.cmd_list[i], dev_in_val[i],
                                              &input_value, sizeof(double),
                                              nullptr, 0, nullptr);
@@ -153,7 +153,7 @@ std::vector<long double> ZePeak::ze_peak_dp_compute(L0Context &context) {
     std::cout << "Input value copy encoded\n";
 
   if (context.sub_device_count) {
-    for (auto i = 0; i < context.sub_device_count; i++) {
+    for (uint32_t i = 0U; i < context.sub_device_count; i++) {
       result =
           zeCommandListAppendBarrier(context.cmd_list[i], nullptr, 0, nullptr);
       if (result) {

--- a/perf_tests/ze_peak/src/global_bw.cpp
+++ b/perf_tests/ze_peak/src/global_bw.cpp
@@ -112,7 +112,7 @@ void ZePeak::ze_peak_global_bw(L0Context &context) {
     std::cout << "outputBuf device buffer allocated\n";
 
   if (context.sub_device_count) {
-    for (auto i = 0; i < context.sub_device_count; i++) {
+    for (uint32_t i = 0U; i < context.sub_device_count; i++) {
       result = zeCommandListAppendMemoryCopy(
           context.cmd_list[i], dev_in_val[i], arr.data(),
           ((arr.size() / context.sub_device_count) * sizeof(float)), nullptr, 0,
@@ -135,7 +135,7 @@ void ZePeak::ze_peak_global_bw(L0Context &context) {
     std::cout << "Input buffer copy encoded\n";
 
   if (context.sub_device_count) {
-    for (auto i = 0; i < context.sub_device_count; i++) {
+    for (uint32_t i = 0U; i < context.sub_device_count; i++) {
       result =
           zeCommandListAppendBarrier(context.cmd_list[i], nullptr, 0, nullptr);
       if (result) {

--- a/perf_tests/ze_peak/src/integer_compute.cpp
+++ b/perf_tests/ze_peak/src/integer_compute.cpp
@@ -115,7 +115,7 @@ std::vector<long double> ZePeak::ze_peak_int_compute(L0Context &context) {
     std::cout << "device output buffer allocated\n";
 
   if (context.sub_device_count) {
-    for (auto i = 0; i < context.sub_device_count; i++) {
+    for (uint32_t i = 0U; i < context.sub_device_count; i++) {
       result = zeCommandListAppendMemoryCopy(context.cmd_list[i], dev_in_val[i],
                                              &input_value, sizeof(int), nullptr,
                                              0, nullptr);
@@ -139,7 +139,7 @@ std::vector<long double> ZePeak::ze_peak_int_compute(L0Context &context) {
     std::cout << "Input value copy encoded\n";
 
   if (context.sub_device_count) {
-    for (auto i = 0; i < context.sub_device_count; i++) {
+    for (uint32_t i = 0U; i < context.sub_device_count; i++) {
       result =
           zeCommandListAppendBarrier(context.cmd_list[i], nullptr, 0, nullptr);
       if (result) {

--- a/perf_tests/ze_peak/src/sp_compute.cpp
+++ b/perf_tests/ze_peak/src/sp_compute.cpp
@@ -111,7 +111,7 @@ void ZePeak::ze_peak_sp_compute(L0Context &context) {
     std::cout << "device output buffer allocated\n";
 
   if (context.sub_device_count) {
-    for (auto i = 0; i < context.sub_device_count; i++) {
+    for (uint32_t i = 0U; i < context.sub_device_count; i++) {
       result = zeCommandListAppendMemoryCopy(context.cmd_list[i], dev_in_val[i],
                                              &input_value, sizeof(float),
                                              nullptr, 0, nullptr);
@@ -134,7 +134,7 @@ void ZePeak::ze_peak_sp_compute(L0Context &context) {
     std::cout << "Input value copy encoded\n";
 
   if (context.sub_device_count) {
-    for (auto i = 0; i < context.sub_device_count; i++) {
+    for (uint32_t i = 0U; i < context.sub_device_count; i++) {
       result =
           zeCommandListAppendBarrier(context.cmd_list[i], nullptr, 0, nullptr);
       if (result) {

--- a/perf_tests/ze_peak/src/transfer_bw.cpp
+++ b/perf_tests/ze_peak/src/transfer_bw.cpp
@@ -186,7 +186,7 @@ void ZePeak::_transfer_bw_shared_memory(L0Context &context,
   gflops = 0;
   if (context.sub_device_count) {
     current_sub_device_id = 0;
-    for (auto i = 0; i < context.sub_device_count; i++) {
+    for (uint32_t i = 0U; i < context.sub_device_count; i++) {
       gflops +=
           _transfer_bw_gpu_copy(context, shared_buf[i], local_memory,
                                 local_memory_size / context.sub_device_count);
@@ -203,7 +203,7 @@ void ZePeak::_transfer_bw_shared_memory(L0Context &context,
   gflops = 0;
   if (context.sub_device_count) {
     current_sub_device_id = 0;
-    for (auto i = 0; i < context.sub_device_count; i++) {
+    for (uint32_t i = 0U; i < context.sub_device_count; i++) {
       gflops +=
           _transfer_bw_gpu_copy(context, local_memory, shared_buf[i],
                                 local_memory_size / context.sub_device_count);
@@ -220,7 +220,7 @@ void ZePeak::_transfer_bw_shared_memory(L0Context &context,
   gflops = 0;
   if (context.sub_device_count) {
     current_sub_device_id = 0;
-    for (auto i = 0; i < context.sub_device_count; i++) {
+    for (uint32_t i = 0U; i < context.sub_device_count; i++) {
       gflops += _transfer_bw_host_copy(
           context, shared_buf[i], local_memory,
           local_memory_size / context.sub_device_count, true);
@@ -237,7 +237,7 @@ void ZePeak::_transfer_bw_shared_memory(L0Context &context,
   gflops = 0;
   if (context.sub_device_count) {
     current_sub_device_id = 0;
-    for (auto i = 0; i < context.sub_device_count; i++) {
+    for (uint32_t i = 0U; i < context.sub_device_count; i++) {
       gflops += _transfer_bw_host_copy(
           context, local_memory, shared_buf[i],
           local_memory_size / context.sub_device_count, false);
@@ -333,7 +333,7 @@ void ZePeak::ze_peak_transfer_bw(L0Context &context) {
   gflops = 0;
   if (context.sub_device_count) {
     current_sub_device_id = 0;
-    for (auto i = 0; i < context.sub_device_count; i++) {
+    for (uint32_t i = 0U; i < context.sub_device_count; i++) {
       gflops +=
           _transfer_bw_gpu_copy(context, dev_out_buf[i], host_memory,
                                 local_memory_size / context.sub_device_count);
@@ -350,7 +350,7 @@ void ZePeak::ze_peak_transfer_bw(L0Context &context) {
   gflops = 0;
   if (context.sub_device_count) {
     current_sub_device_id = 0;
-    for (auto i = 0; i < context.sub_device_count; i++) {
+    for (uint32_t i = 0U; i < context.sub_device_count; i++) {
       gflops +=
           _transfer_bw_gpu_copy(context, host_memory, dev_out_buf[i],
                                 local_memory_size / context.sub_device_count);

--- a/perf_tests/ze_peak/src/ze_peak.cpp
+++ b/perf_tests/ze_peak/src/ze_peak.cpp
@@ -583,7 +583,7 @@ void L0Context::execute_commandlist_and_sync(bool use_copy_only_queue) {
   ze_result_t result = ZE_RESULT_SUCCESS;
 
   if (sub_device_count) {
-    for (auto i = 0; i < sub_device_count; i++) {
+    for (uint32_t i = 0U; i < sub_device_count; i++) {
       auto cmd_l = use_copy_only_queue ? copy_command_list : cmd_list[i];
       auto cmd_q = use_copy_only_queue ? copy_command_queue : cmd_queue[i];
 
@@ -1821,7 +1821,7 @@ long double ZePeak::context_time_in_us(L0Context &context,
 
   const uint64_t timestamp_freq = context.device_property.timerResolution;
   const uint64_t timestamp_max_value =
-      ~(-1L << context.device_property.kernelTimestampValidBits);
+      ~(-1ULL << context.device_property.kernelTimestampValidBits);
   context_time_ns =
       (ts_result.global.kernelEnd >= ts_result.global.kernelStart)
           ? (ts_result.global.kernelEnd - ts_result.global.kernelStart) *

--- a/perf_tests/ze_peer/src/ze_peer.cpp
+++ b/perf_tests/ze_peer/src/ze_peer.cpp
@@ -94,7 +94,7 @@ void run_ipc_test(int size_to_run, uint32_t remote_device_id,
   print_results_header(remote_device_ids, local_device_ids, pair_device_ids,
                        test_type, transfer_type);
 
-  for (int number_of_elements = 8; number_of_elements <= max_number_of_elements;
+  for (size_t number_of_elements = 8; number_of_elements <= max_number_of_elements;
        number_of_elements *= 2) {
     if (size_to_run != -1) {
       number_of_elements = size_to_run;
@@ -152,7 +152,7 @@ void run_test(int size_to_run, std::vector<uint32_t> &remote_device_ids,
   print_results_header(remote_device_ids, local_device_ids, pair_device_ids,
                        test_type, transfer_type);
 
-  for (int number_of_elements = 8; number_of_elements <= max_number_of_elements;
+  for (size_t number_of_elements = 8; number_of_elements <= max_number_of_elements;
        number_of_elements *= 2) {
     if (size_to_run != -1) {
       number_of_elements = size_to_run;

--- a/perf_tests/ze_peer/src/ze_peer_bidirectional.cpp
+++ b/perf_tests/ze_peer/src/ze_peer_bidirectional.cpp
@@ -41,7 +41,7 @@ void ZePeer::bidirectional_perform_copy(
   Timer<std::chrono::microseconds::period> timer;
 
   /* Warm up */
-  for (int i = 0; i < warm_up_iterations; i++) {
+  for (uint32_t i = 0U; i < warm_up_iterations; i++) {
     SUCCESS_OR_TERMINATE(zeEventHostSignal(event));
     SUCCESS_OR_TERMINATE(zeCommandQueueExecuteCommandLists(
         local_command_queue, 1, &local_command_list, nullptr));
@@ -56,7 +56,7 @@ void ZePeer::bidirectional_perform_copy(
 
   do {
     long double time_usec = 0;
-    for (int i = 0; i < number_iterations; i++) {
+    for (uint32_t i = 0U; i < number_iterations; i++) {
       SUCCESS_OR_TERMINATE(zeCommandQueueExecuteCommandLists(
           local_command_queue, 1, &local_command_list, nullptr));
       SUCCESS_OR_TERMINATE(zeCommandQueueExecuteCommandLists(

--- a/perf_tests/ze_peer/src/ze_peer_parallel_multiple_targets.cpp
+++ b/perf_tests/ze_peer/src/ze_peer_parallel_multiple_targets.cpp
@@ -139,7 +139,7 @@ void ZePeer::perform_bidirectional_parallel_copy_to_multiple_targets(
   }
 
   /* Warm up */
-  for (int i = 0; i < warm_up_iterations; i++) {
+  for (uint32_t i = 0U; i < warm_up_iterations; i++) {
     queue_index_iter = 0;
     for (size_t local_device_id_iter = 0;
          local_device_id_iter < local_device_ids.size();
@@ -203,21 +203,21 @@ void ZePeer::perform_bidirectional_parallel_copy_to_multiple_targets(
   Timer<std::chrono::microseconds::period> timer;
   std::vector<std::vector<Timer<std::chrono::microseconds::period>>> timers(
       ze_peer_devices.size());
-  for (int i = 0; i < timers.size(); i++) {
+  for (size_t i = 0U; i < timers.size(); i++) {
     timers[i].resize(ze_peer_devices.size());
   }
 
   std::vector<std::vector<long double>> times(ze_peer_devices.size());
-  for (int i = 0; i < times.size(); i++) {
+  for (size_t i = 0U; i < times.size(); i++) {
     times[i].resize(ze_peer_devices.size());
-    for (int j = 0; j < times.size(); j++) {
+    for (size_t j = 0U; j < times.size(); j++) {
       times[i][j] = 0;
     }
   }
 
   do {
     timer.start();
-    for (int i = 0; i < number_iterations; i++) {
+    for (uint32_t i = 0U; i < number_iterations; i++) {
       queue_index_iter = 0;
       for (size_t local_device_id_iter = 0;
            local_device_id_iter < local_device_ids.size();
@@ -472,7 +472,7 @@ void ZePeer::perform_parallel_copy_to_multiple_targets(
 
   /* Warm up */
   queue_index_iter = 0;
-  for (int i = 0; i < warm_up_iterations; i++) {
+  for (uint32_t i = 0U; i < warm_up_iterations; i++) {
     for (size_t local_device_id_iter = 0;
          local_device_id_iter < local_device_ids.size();
          local_device_id_iter++) {
@@ -532,21 +532,21 @@ void ZePeer::perform_parallel_copy_to_multiple_targets(
   Timer<std::chrono::microseconds::period> timer;
   std::vector<std::vector<Timer<std::chrono::microseconds::period>>> timers(
       ze_peer_devices.size());
-  for (int i = 0; i < timers.size(); i++) {
+  for (size_t i = 0U; i < timers.size(); i++) {
     timers[i].resize(ze_peer_devices.size());
   }
 
   std::vector<std::vector<long double>> times(ze_peer_devices.size());
-  for (int i = 0; i < times.size(); i++) {
+  for (size_t i = 0U; i < times.size(); i++) {
     times[i].resize(ze_peer_devices.size());
-    for (int j = 0; j < times.size(); j++) {
+    for (size_t j = 0U; j < times.size(); j++) {
       times[i][j] = 0;
     }
   }
 
   do {
     timer.start();
-    for (int i = 0; i < number_iterations; i++) {
+    for (uint32_t i = 0U; i < number_iterations; i++) {
       queue_index_iter = 0;
       for (size_t local_device_id_iter = 0;
            local_device_id_iter < local_device_ids.size();

--- a/perf_tests/ze_peer/src/ze_peer_parallel_pair_targets.cpp
+++ b/perf_tests/ze_peer/src/ze_peer_parallel_pair_targets.cpp
@@ -126,7 +126,7 @@ void ZePeer::perform_bidirectional_parallel_copy_to_pair_targets(
   }
 
   /* Warm up */
-  for (int i = 0; i < warm_up_iterations; i++) {
+  for (uint32_t i = 0U; i < warm_up_iterations; i++) {
     queue_index_iter = 0;
     for (auto pair_device_id : pair_device_ids) {
       auto local_device_id = pair_device_id.first;
@@ -183,21 +183,21 @@ void ZePeer::perform_bidirectional_parallel_copy_to_pair_targets(
   Timer<std::chrono::microseconds::period> timer;
   std::vector<std::vector<Timer<std::chrono::microseconds::period>>> timers(
       ze_peer_devices.size());
-  for (int i = 0; i < timers.size(); i++) {
+  for (size_t i = 0U; i < timers.size(); i++) {
     timers[i].resize(ze_peer_devices.size());
   }
 
   std::vector<std::vector<long double>> times(ze_peer_devices.size());
-  for (int i = 0; i < times.size(); i++) {
+  for (size_t i = 0U; i < times.size(); i++) {
     times[i].resize(ze_peer_devices.size());
-    for (int j = 0; j < times.size(); j++) {
+    for (size_t j = 0U; j < times.size(); j++) {
       times[i][j] = 0;
     }
   }
 
   do {
     timer.start();
-    for (int i = 0; i < number_iterations; i++) {
+    for (uint32_t i = 0U; i < number_iterations; i++) {
       queue_index_iter = 0;
       for (auto pair_device_id : pair_device_ids) {
         auto local_device_id = pair_device_id.first;
@@ -420,7 +420,7 @@ void ZePeer::perform_parallel_copy_to_pair_targets(
   }
 
   /* Warm up */
-  for (int i = 0; i < warm_up_iterations; i++) {
+  for (uint32_t i = 0U; i < warm_up_iterations; i++) {
     queue_index_iter = 0;
     for (auto pair_device_id : pair_device_ids) {
       auto local_device_id = pair_device_id.first;
@@ -475,21 +475,21 @@ void ZePeer::perform_parallel_copy_to_pair_targets(
   Timer<std::chrono::microseconds::period> timer;
   std::vector<std::vector<Timer<std::chrono::microseconds::period>>> timers(
       ze_peer_devices.size());
-  for (int i = 0; i < timers.size(); i++) {
+  for (size_t i = 0U; i < timers.size(); i++) {
     timers[i].resize(ze_peer_devices.size());
   }
 
   std::vector<std::vector<long double>> times(ze_peer_devices.size());
-  for (int i = 0; i < times.size(); i++) {
+  for (size_t i = 0U; i < times.size(); i++) {
     times[i].resize(ze_peer_devices.size());
-    for (int j = 0; j < times.size(); j++) {
+    for (size_t j = 0U; j < times.size(); j++) {
       times[i][j] = 0;
     }
   }
 
   do {
     timer.start();
-    for (int i = 0; i < number_iterations; i++) {
+    for (uint32_t i = 0U; i < number_iterations; i++) {
       queue_index_iter = 0;
       for (auto pair_device_id : pair_device_ids) {
         auto local_device_id = pair_device_id.first;

--- a/perf_tests/ze_peer/src/ze_peer_parallel_single_target.cpp
+++ b/perf_tests/ze_peer/src/ze_peer_parallel_single_target.cpp
@@ -64,7 +64,7 @@ void ZePeer::perform_bidirectional_parallel_copy_to_single_target(
   Timer<std::chrono::microseconds::period> timer;
 
   /* Warm up */
-  for (int i = 0; i < warm_up_iterations; i++) {
+  for (uint32_t i = 0U; i < warm_up_iterations; i++) {
     SUCCESS_OR_TERMINATE(zeEventHostSignal(event));
     for (size_t e = 0; e < num_engines; e++) {
       SUCCESS_OR_TERMINATE(zeCommandQueueExecuteCommandLists(
@@ -88,7 +88,7 @@ void ZePeer::perform_bidirectional_parallel_copy_to_single_target(
 
   do {
     timer.start();
-    for (int i = 0; i < number_iterations; i++) {
+    for (uint32_t i = 0U; i < number_iterations; i++) {
       for (size_t e = 0; e < num_engines; e++) {
         SUCCESS_OR_TERMINATE(zeCommandQueueExecuteCommandLists(
             ze_peer_devices[local_device_id].engines[queues[e]].first, 1,
@@ -157,7 +157,7 @@ void ZePeer::perform_parallel_copy_to_single_target(
   Timer<std::chrono::microseconds::period> timer;
 
   /* Warm up */
-  for (int i = 0; i < warm_up_iterations; i++) {
+  for (uint32_t i = 0U; i < warm_up_iterations; i++) {
     for (size_t e = 0; e < num_engines; e++) {
       SUCCESS_OR_TERMINATE(zeCommandQueueExecuteCommandLists(
           ze_peer_devices[queue_device_id].engines[queues[e]].first, 1,
@@ -178,7 +178,7 @@ void ZePeer::perform_parallel_copy_to_single_target(
 
   do {
     long double time_usec = 0;
-    for (int i = 0; i < number_iterations; i++) {
+    for (uint32_t i = 0U; i < number_iterations; i++) {
       for (size_t e = 0; e < num_engines; e++) {
         SUCCESS_OR_TERMINATE(zeCommandQueueExecuteCommandLists(
             ze_peer_devices[queue_device_id].engines[queues[e]].first, 1,

--- a/perf_tests/ze_peer/src/ze_peer_unidirectional.cpp
+++ b/perf_tests/ze_peer/src/ze_peer_unidirectional.cpp
@@ -20,7 +20,7 @@ void ZePeer::perform_copy(peer_test_t test_type,
   Timer<std::chrono::microseconds::period> timer;
 
   /* Warm up */
-  for (int i = 0; i < warm_up_iterations; i++) {
+  for (uint32_t i = 0U; i < warm_up_iterations; i++) {
     SUCCESS_OR_TERMINATE(zeCommandQueueExecuteCommandLists(
         command_queue, 1, &command_list, nullptr));
     SUCCESS_OR_TERMINATE(zeCommandQueueSynchronize(
@@ -29,7 +29,7 @@ void ZePeer::perform_copy(peer_test_t test_type,
 
   do {
     timer.start();
-    for (int i = 0; i < number_iterations; i++) {
+    for (uint32_t i = 0U; i < number_iterations; i++) {
       SUCCESS_OR_TERMINATE(zeCommandQueueExecuteCommandLists(
           command_queue, 1, &command_list, nullptr));
       SUCCESS_OR_TERMINATE(zeCommandQueueSynchronize(

--- a/utils/image/include/image/image.hpp
+++ b/utils/image/include/image/image.hpp
@@ -20,15 +20,15 @@ public:
   virtual bool read(const std::string &image_path) = 0;
   virtual bool write(const std::string &image_path) = 0;
   virtual bool write(const std::string &image_path, const T *data) = 0;
-  virtual int width() const = 0;
-  virtual int height() const = 0;
-  virtual int number_of_channels() const = 0;
-  virtual int bits_per_channel() const = 0;
-  virtual int bits_per_pixel() const = 0;
-  virtual int size() const = 0;
-  virtual int size_in_bytes() const = 0;
-  virtual T get_pixel(const int x, const int y) const = 0;
-  virtual void set_pixel(const int x, const int y, const T data) = 0;
+  virtual uint32_t width() const = 0;
+  virtual uint32_t height() const = 0;
+  virtual uint16_t number_of_channels() const = 0;
+  virtual uint16_t bits_per_channel() const = 0;
+  virtual uint16_t bits_per_pixel() const = 0;
+  virtual size_t size() const = 0;
+  virtual size_t size_in_bytes() const = 0;
+  virtual T get_pixel(const uint32_t x, const uint32_t y) const = 0;
+  virtual void set_pixel(const uint32_t x, const uint32_t y, const T data) = 0;
   virtual std::vector<T> get_pixels() const = 0;
   virtual void copy_raw_data(const T *data) = 0;
   virtual T *raw_data() = 0;
@@ -39,20 +39,20 @@ template <typename T> class ImagePNG : public Image<T> {
 public:
   ImagePNG();
   ImagePNG(const std::string &image_path);
-  ImagePNG(const int width, const int height);
-  ImagePNG(const int width, const int height, const std::vector<T> &data);
+  ImagePNG(const uint32_t width, const uint32_t height);
+  ImagePNG(const uint32_t width, const uint32_t height, const std::vector<T> &data);
   bool read(const std::string &image_path) override;
   bool write(const std::string &image_path) override;
   bool write(const std::string &image_path, const T *data) override;
-  int width() const override;
-  int height() const override;
-  int number_of_channels() const override;
-  int bits_per_channel() const override;
-  int bits_per_pixel() const override;
-  int size() const override;
-  int size_in_bytes() const override;
-  T get_pixel(const int x, const int y) const override;
-  void set_pixel(const int x, const int y, const T data) override;
+  uint32_t width() const override;
+  uint32_t height() const override;
+  uint16_t number_of_channels() const override;
+  uint16_t bits_per_channel() const override;
+  uint16_t bits_per_pixel() const override;
+  size_t size() const override;
+  size_t size_in_bytes() const override;
+  T get_pixel(const uint32_t x, const uint32_t y) const override;
+  void set_pixel(const uint32_t x, const uint32_t y, const T data) override;
   std::vector<T> get_pixels() const override;
   void copy_raw_data(const T *data) override;
   T *raw_data() override;
@@ -63,8 +63,8 @@ public:
 
 private:
   std::vector<T> pixels_;
-  int width_;
-  int height_;
+  uint32_t width_;
+  uint32_t height_;
 };
 
 typedef ImagePNG<uint32_t> ImagePNG32Bit;
@@ -73,20 +73,20 @@ template <typename T> class ImageBMP : public Image<T> {
 public:
   ImageBMP();
   ImageBMP(const std::string &image_path);
-  ImageBMP(const int width, const int height);
-  ImageBMP(const int width, const int height, const std::vector<T> &data);
+  ImageBMP(const uint32_t width, const uint32_t height);
+  ImageBMP(const uint32_t width, const uint32_t height, const std::vector<T> &data);
   bool read(const std::string &image_path) override;
   bool write(const std::string &image_path) override;
   bool write(const std::string &image_path, const T *data) override;
-  int width() const override;
-  int height() const override;
-  int number_of_channels() const override;
-  int bits_per_channel() const override;
-  int bits_per_pixel() const override;
-  int size() const override;
-  int size_in_bytes() const override;
-  T get_pixel(const int x, const int y) const override;
-  void set_pixel(const int x, const int y, const T data) override;
+  uint32_t width() const override;
+  uint32_t height() const override;
+  uint16_t number_of_channels() const override;
+  uint16_t bits_per_channel() const override;
+  uint16_t bits_per_pixel() const override;
+  size_t size() const override;
+  size_t size_in_bytes() const override;
+  T get_pixel(const uint32_t x, const uint32_t y) const override;
+  void set_pixel(const uint32_t x, const uint32_t y, const T data) override;
   std::vector<T> get_pixels() const override;
   void copy_raw_data(const T *data) override;
   T *raw_data() override;
@@ -96,8 +96,8 @@ public:
 
 private:
   std::vector<T> pixels_;
-  int width_;
-  int height_;
+  uint32_t width_;
+  uint32_t height_;
 };
 
 typedef ImageBMP<uint8_t> ImageBMP8Bit;

--- a/utils/image/src/bmp.cpp
+++ b/utils/image/src/bmp.cpp
@@ -29,14 +29,14 @@ struct BMPFileHeader {
 
 struct BMPInfoHeader {
   uint32_t bi_size_;      // length of info header
-  int32_t bi_width_;      // width of bitmap in pixels
-  int32_t bi_height_;     // height of bitmap in pixels
+  uint32_t bi_width_;     // width of bitmap in pixels
+  uint32_t bi_height_;    // height of bitmap in pixels
   uint16_t bi_planes_;    // number of color planes - must be 1
   uint16_t bi_bit_count_; // bit depth
   uint32_t bi_compression_;
   uint32_t bi_size_image_; // size of picture in bytes
-  int32_t bi_x_pels_per_meter_;
-  int32_t bi_y_pels_per_meter_;
+  uint32_t bi_x_pels_per_meter_;
+  uint32_t bi_y_pels_per_meter_;
   uint32_t bi_clr_used_;
   uint32_t bi_clr_important_;
 };
@@ -53,7 +53,7 @@ struct BMPRGBQUAD_t {
 
 const uint32_t BI_RGB = 0;
 
-bool BmpUtils::save_image_as_bmp(uint32_t *ptr, int width, int height,
+bool BmpUtils::save_image_as_bmp(uint32_t *ptr, uint32_t width, uint32_t height,
                                  const char *file_name) {
   FILE *stream = nullptr;
   uint32_t *ppix = ptr;
@@ -103,8 +103,8 @@ bool BmpUtils::save_image_as_bmp(uint32_t *ptr, int width, int height,
 
   uint8_t buffer[4];
   memset(buffer, 0, sizeof(buffer));
-  for (int y = 0; y < height; y++) {
-    for (int x = 0; x < width; x++) {
+  for (uint32_t y = 0; y < height; y++) {
+    for (uint32_t x = 0; x < width; x++) {
       ppix = ptr + (height - 1 - y) * width + x;
       if (4 != fwrite(ppix, 1, 4, stream)) {
         goto error_exit;
@@ -121,8 +121,8 @@ error_exit:
   return false;
 }
 
-bool BmpUtils::save_image_as_bmp_32fc4(float *ptr, float scale, int width,
-                                       int height, const char *file_name) {
+bool BmpUtils::save_image_as_bmp_32fc4(float *ptr, float scale, uint32_t width,
+                                       uint32_t height, const char *file_name) {
   // save results in bitmap files
   float tmp_f_val = 0.0f;
   uint32_t *out_u_int_buf =
@@ -132,8 +132,8 @@ bool BmpUtils::save_image_as_bmp_32fc4(float *ptr, float scale, int width,
     return false;
   }
 
-  for (int y = 0; y < height; y++) {
-    for (int x = 0; x < width; x++) {
+  for (uint32_t y = 0U; y < height; y++) {
+    for (uint32_t x = 0U; x < width; x++) {
       // Ensure that no value is greater than 255.0
       uint32_t ui_tmp[4];
       tmp_f_val = (scale * ptr[(y * width + x) * 4 + 0]);
@@ -168,7 +168,7 @@ bool BmpUtils::save_image_as_bmp_32fc4(float *ptr, float scale, int width,
   return res;
 }
 
-bool BmpUtils::save_image_as_bmp_8u(uint8_t *ptr, int width, int height,
+bool BmpUtils::save_image_as_bmp_8u(uint8_t *ptr, uint32_t width, uint32_t height,
                                     const char *file_name) {
   uint32_t *out_u_int_buf =
       (uint32_t *)malloc(width * height * sizeof(uint32_t));
@@ -177,8 +177,8 @@ bool BmpUtils::save_image_as_bmp_8u(uint8_t *ptr, int width, int height,
     return false;
   }
 
-  for (int y = 0; y < height; y++) {
-    for (int x = 0; x < width; x++) {
+  for (uint32_t y = 0U; y < height; y++) {
+    for (uint32_t x = 0U; x < width; x++) {
       uint8_t uc_data = ptr[y * width + x];
 
       uint32_t ui_data =
@@ -193,8 +193,8 @@ bool BmpUtils::save_image_as_bmp_8u(uint8_t *ptr, int width, int height,
   return res;
 }
 
-bool BmpUtils::load_bmp_image(uint8_t *&data, int &width, int &height,
-                              int &pitch, uint16_t &bits_per_pixel,
+bool BmpUtils::load_bmp_image(uint8_t *&data, uint32_t &width, uint32_t &height,
+                              uint32_t &pitch, uint16_t &bits_per_pixel,
                               const char *file_name) {
   FILE *stream = nullptr;
 
@@ -240,15 +240,15 @@ bool BmpUtils::load_bmp_image(uint8_t *&data, int &width, int &height,
     goto error_exit;
 
   if (info_header.bi_height_ > 0) {
-    for (int h = 0; h < height; h++) {
+    for (uint32_t h = 0; h < height; h++) {
       uint8_t *dst = data + (height - h - 1) * pitch;
-      if (pitch != static_cast<int>(fread(dst, 1, pitch, stream))) {
+      if (pitch != static_cast<uint32_t>(fread(dst, 1, pitch, stream))) {
         goto error_exit;
       }
     }
   } else {
     if (height * pitch !=
-        static_cast<int>(fread(data, 1, height * pitch, stream))) {
+        static_cast<uint32_t>(fread(data, 1, height * pitch, stream))) {
       goto error_exit;
     }
   }
@@ -261,10 +261,10 @@ error_exit:
   return false;
 }
 
-bool BmpUtils::load_bmp_image_8u(uint8_t *&data, int &width, int &height,
+bool BmpUtils::load_bmp_image_8u(uint8_t *&data, uint32_t &width, uint32_t &height,
                                  const char *file_name) {
   // First, load the BMP image generally:
-  int src_pitch = 0;
+  uint32_t src_pitch = 0;
   uint16_t src_bits_per_pixel = 0;
 
   bool success = load_bmp_image(data, width, height, src_pitch,
@@ -275,11 +275,11 @@ bool BmpUtils::load_bmp_image_8u(uint8_t *&data, int &width, int &height,
     success = false;
   }
 
-  if ((width > (1 << 16)) || (height > (1 << 16))) {
+  if ((width > (1U << 16)) || (height > (1U << 16))) {
     success = false;
   }
 
-  int dst_pitch = width;
+  uint32_t dst_pitch = width;
   uint8_t *data8u = nullptr;
 
   if (success) {
@@ -287,7 +287,7 @@ bool BmpUtils::load_bmp_image_8u(uint8_t *&data, int &width, int &height,
     if (nullptr == data8u) {
       success = false;
     }
-    if ((width > (1 << 16)) || (height > (1 << 16))) {
+    if ((width > (1U << 16)) || (height > (1U << 16))) {
       success = false;
     }
   }
@@ -298,12 +298,12 @@ bool BmpUtils::load_bmp_image_8u(uint8_t *&data, int &width, int &height,
     uint16_t src_bytes_per_pixel = (src_bits_per_pixel + 7) / 8;
     uint16_t dst_bytes_per_pixel = 1;
 
-    for (int h = 0; h < height;
+    for (uint32_t h = 0U; h < height;
          h++, src_start += src_pitch, dst_start += dst_pitch) {
       uint8_t *src_pixel = src_start;
       uint8_t *dst_pixel = dst_start;
 
-      for (int w = 0; w < width; w++, src_pixel += src_bytes_per_pixel,
+      for (uint32_t w = 0U; w < width; w++, src_pixel += src_bytes_per_pixel,
                dst_pixel += dst_bytes_per_pixel) {
         switch (src_bits_per_pixel) {
         case 8:

--- a/utils/image/src/bmp.hpp
+++ b/utils/image/src/bmp.hpp
@@ -16,17 +16,17 @@ namespace level_zero_tests {
 
 class BmpUtils {
 public:
-  static bool save_image_as_bmp(uint32_t *ptr, int width, int height,
+  static bool save_image_as_bmp(uint32_t *ptr, uint32_t width, uint32_t height,
                                 const char *file_name);
-  static bool save_image_as_bmp_32fc4(float *ptr, float scale, int width,
-                                      int height, const char *file_name);
-  static bool save_image_as_bmp_8u(uint8_t *ptr, int width, int height,
+  static bool save_image_as_bmp_32fc4(float *ptr, float scale, uint32_t width,
+                                      uint32_t height, const char *file_name);
+  static bool save_image_as_bmp_8u(uint8_t *ptr, uint32_t width, uint32_t height,
                                    const char *file_name);
 
-  static bool load_bmp_image(uint8_t *&data, int &width, int &height,
-                             int &pitch, uint16_t &bits_per_pixel,
+  static bool load_bmp_image(uint8_t *&data, uint32_t &width, uint32_t &height,
+                             uint32_t &pitch, uint16_t &bits_per_pixel,
                              const char *file_name);
-  static bool load_bmp_image_8u(uint8_t *&data, int &width, int &height,
+  static bool load_bmp_image_8u(uint8_t *&data, uint32_t &width, uint32_t &height,
                                 const char *file_name);
 };
 } // namespace level_zero_tests

--- a/utils/image/src/image.cpp
+++ b/utils/image/src/image.cpp
@@ -32,20 +32,20 @@ namespace gil = boost::gil;
 #include "bmp.hpp"
 
 namespace level_zero_tests {
-template <typename T> ImagePNG<T>::ImagePNG() : width_(0), height_(0) {}
+template <typename T> ImagePNG<T>::ImagePNG() : width_(0U), height_(0U) {}
 
 template <typename T> ImagePNG<T>::ImagePNG(const std::string &image_path) {
   read(image_path);
 }
 
 template <typename T>
-ImagePNG<T>::ImagePNG(const int width, const int height)
+ImagePNG<T>::ImagePNG(const uint32_t width, const uint32_t height)
     : width_(width), height_(height) {
   pixels_.resize(size());
 }
 
 template <typename T>
-ImagePNG<T>::ImagePNG(const int width, const int height,
+ImagePNG<T>::ImagePNG(const uint32_t width, const uint32_t height,
                       const std::vector<T> &data)
     : width_(width), height_(height), pixels_(data) {}
 
@@ -62,23 +62,22 @@ template <> bool ImagePNG<uint32_t>::read(const std::string &image_path) {
         (pixel[0] << 24) + (pixel[1] << 16) + (pixel[2] << 8) + pixel[3];
     pixels_.push_back(raw_pixel);
   }
-  width_ = static_cast<int>(view.width());
-  height_ = static_cast<int>(view.height());
+  width_ = static_cast<uint32_t>(view.width());
+  height_ = static_cast<uint32_t>(view.height());
   return false;
 }
 
 template <> bool ImagePNG<uint32_t>::write(const std::string &image_path) {
   gil::rgba8_image_t image(width(), height());
-  std::vector<gil::rgba8_pixel_t> channels;
   gil::rgba8_view_t view = gil::view(image);
-  for (int id = 0; id < static_cast<int>(pixels_.size()); ++id) {
-    uint32_t raw_pixel = pixels_[id];
+  for (size_t idx = 0; idx < pixels_.size(); ++idx) {
+    uint32_t raw_pixel = pixels_[idx];
     gil::rgba8_pixel_t pixel;
     pixel[3] = raw_pixel & 0xFF;
     pixel[2] = (raw_pixel >> 8) & 0xFF;
     pixel[1] = (raw_pixel >> 16) & 0xFF;
     pixel[0] = (raw_pixel >> 24) & 0xFF;
-    view[id] = pixel;
+    view[idx] = pixel;
   }
 #ifdef BOOST_GIL_IO_PNG_168_API
   gil::write_view(image_path, view, gil::png_tag());
@@ -94,39 +93,39 @@ bool ImagePNG<T>::write(const std::string &image_path, const T *data) {
   return write(image_path);
 }
 
-template <typename T> int ImagePNG<T>::width() const { return width_; }
+template <typename T> uint32_t ImagePNG<T>::width() const { return width_; }
 
-template <typename T> int ImagePNG<T>::height() const { return height_; }
+template <typename T> uint32_t ImagePNG<T>::height() const { return height_; }
 
-template <typename T> int ImagePNG<T>::number_of_channels() const {
+template <typename T> uint16_t ImagePNG<T>::number_of_channels() const {
   return bits_per_pixel() / bits_per_channel();
 }
 
-template <typename T> int ImagePNG<T>::bits_per_channel() const { return 8; }
+template <typename T> uint16_t ImagePNG<T>::bits_per_channel() const { return 8; }
 
-template <typename T> int ImagePNG<T>::bits_per_pixel() const {
+template <typename T> uint16_t ImagePNG<T>::bits_per_pixel() const {
   return std::numeric_limits<T>::digits;
 }
 
-template <typename T> int ImagePNG<T>::size() const {
-  return width() * height();
+template <typename T> size_t ImagePNG<T>::size() const {
+  return static_cast<size_t>(width()) * static_cast<size_t>(height());
 }
 
-template <typename T> int ImagePNG<T>::size_in_bytes() const {
-  return static_cast<int>(pixels_.size() * sizeof(T));
+template <typename T> size_t ImagePNG<T>::size_in_bytes() const {
+  return pixels_.size() * sizeof(T);
 }
 
-template <typename T> T ImagePNG<T>::get_pixel(const int x, const int y) const {
+template <typename T> T ImagePNG<T>::get_pixel(const uint32_t x, const uint32_t y) const {
   return pixels_[y * width() + x];
 }
 
 template <typename T>
-void ImagePNG<T>::set_pixel(const int x, const int y, const T data) {
+void ImagePNG<T>::set_pixel(const uint32_t x, const uint32_t y, const T data) {
   pixels_[y * width() + x] = data;
 }
 
 template <typename T>
-std::vector<T> level_zero_tests::ImagePNG<T>::get_pixels() const {
+std::vector<T> ImagePNG<T>::get_pixels() const {
   return pixels_;
 }
 
@@ -146,8 +145,8 @@ bool ImagePNG<T>::operator==(const ImagePNG<T> &rhs) const {
 }
 
 template <typename T> void ImagePNG<T>::dump_image() const {
-  for (int y = 0; y < height(); y++) {
-    for (int x = 0; x < width(); x++) {
+  for (uint32_t y = 0; y < height(); y++) {
+    for (uint32_t x = 0; x < width(); x++) {
       T pixel = get_pixel(x, y);
       LOG_DEBUG << " x: " << x << " y: " << y << " pixel: 0x" << std::hex
                 << pixel;
@@ -157,28 +156,28 @@ template <typename T> void ImagePNG<T>::dump_image() const {
 
 template class ImagePNG<uint32_t>;
 
-template <typename T> ImageBMP<T>::ImageBMP() : width_(0), height_(0) {}
+template <typename T> ImageBMP<T>::ImageBMP() : width_(0U), height_(0U) {}
 
 template <typename T> ImageBMP<T>::ImageBMP(const std::string &image_path) {
   read(image_path);
 }
 
 template <typename T>
-ImageBMP<T>::ImageBMP(const int width, const int height)
+ImageBMP<T>::ImageBMP(const uint32_t width, const uint32_t height)
     : width_(width), height_(height) {
   pixels_.resize(size());
 }
 
 template <typename T>
-ImageBMP<T>::ImageBMP(const int width, const int height,
+ImageBMP<T>::ImageBMP(const uint32_t width, const uint32_t height,
                       const std::vector<T> &data)
     : width_(width), height_(height), pixels_(data) {}
 
 template <typename T> bool ImageBMP<T>::read(const std::string &image_path) {
   std::unique_ptr<uint8_t> data = nullptr;
   uint8_t *tmp = nullptr;
-  int pitch = 0;
-  uint16_t bits_per_pixel = 0;
+  uint32_t pitch = 0U;
+  uint16_t bits_per_pixel = 0U;
   bool error = !BmpUtils::load_bmp_image(tmp, width_, height_, pitch,
                                          bits_per_pixel, image_path.c_str());
   data.reset(tmp);
@@ -214,34 +213,34 @@ bool ImageBMP<T>::write(const std::string &image_path, const T *data) {
   return write(image_path);
 }
 
-template <typename T> int ImageBMP<T>::width() const { return width_; }
+template <typename T> uint32_t ImageBMP<T>::width() const { return width_; }
 
-template <typename T> int ImageBMP<T>::height() const { return height_; }
+template <typename T> uint32_t ImageBMP<T>::height() const { return height_; }
 
-template <typename T> int ImageBMP<T>::number_of_channels() const {
+template <typename T> uint16_t ImageBMP<T>::number_of_channels() const {
   return bits_per_pixel() / bits_per_channel();
 }
 
-template <typename T> int ImageBMP<T>::bits_per_channel() const { return 8; }
+template <typename T> uint16_t ImageBMP<T>::bits_per_channel() const { return 8; }
 
-template <typename T> int ImageBMP<T>::bits_per_pixel() const {
+template <typename T> uint16_t ImageBMP<T>::bits_per_pixel() const {
   return std::numeric_limits<T>::digits;
 }
 
-template <typename T> int ImageBMP<T>::size() const {
-  return width() * height();
+template <typename T> size_t ImageBMP<T>::size() const {
+  return static_cast<size_t>(width()) * static_cast<size_t>(height());
 }
 
-template <typename T> int ImageBMP<T>::size_in_bytes() const {
-  return static_cast<int>(pixels_.size() * sizeof(T));
+template <typename T> size_t ImageBMP<T>::size_in_bytes() const {
+  return pixels_.size() * sizeof(T);
 }
 
-template <typename T> T ImageBMP<T>::get_pixel(const int x, const int y) const {
+template <typename T> T ImageBMP<T>::get_pixel(const uint32_t x, const uint32_t y) const {
   return pixels_[y * width() + x];
 }
 
 template <typename T>
-void ImageBMP<T>::set_pixel(const int x, const int y, const T data) {
+void ImageBMP<T>::set_pixel(const uint32_t x, const uint32_t y, const T data) {
   pixels_[y * width() + x] = data;
 }
 

--- a/utils/test_harness/src/test_harness_cmdlist.cpp
+++ b/utils/test_harness/src/test_harness_cmdlist.cpp
@@ -141,10 +141,10 @@ void append_command_lists_immediate_exp(
       numWaitEvents, phWaitEvents));
   EXPECT_EQ(hCommandList, command_list_initial);
   EXPECT_EQ(hSignalEvent, signal_event_initial);
-  for (int i = 0; i < numCommandLists; i++) {
+  for (uint32_t i = 0U; i < numCommandLists; i++) {
     EXPECT_EQ(phCommandLists[i], command_lists_initial[i]);
   }
-  for (int i = 0; i < numWaitEvents; i++) {
+  for (uint32_t i = 0U; i < numWaitEvents; i++) {
     EXPECT_EQ(phWaitEvents[i], wait_events_initial[i]);
   }
 }
@@ -281,7 +281,7 @@ void append_memory_fill(ze_command_list_handle_t cl, void *dstptr,
       wait_events));
   EXPECT_EQ(cl, command_list_initial);
   EXPECT_EQ(hSignalEvent, signal_event_initial);
-  for (int i = 0; i < num_wait_events; i++) {
+  for (uint32_t i = 0U; i < num_wait_events; i++) {
     EXPECT_EQ(wait_events[i], wait_events_initial[i]);
   }
 }
@@ -313,7 +313,7 @@ void append_memory_copy(ze_command_list_handle_t cl, void *dstptr,
 
   EXPECT_EQ(cl, command_list_initial);
   EXPECT_EQ(hSignalEvent, signal_event_initial);
-  for (int i = 0; i < num_wait_events; i++) {
+  for (uint32_t i = 0U; i < num_wait_events; i++) {
     EXPECT_EQ(wait_events[i], wait_events_initial[i]);
   }
 }
@@ -336,7 +336,7 @@ void append_memory_copy(ze_context_handle_t src_context,
 
   EXPECT_EQ(cl, command_list_initial);
   EXPECT_EQ(hSignalEvent, signal_event_initial);
-  for (int i = 0; i < num_wait_events; i++) {
+  for (uint32_t i = 0U; i < num_wait_events; i++) {
     EXPECT_EQ(wait_events[i], wait_events_initial[i]);
   }
 }
@@ -374,7 +374,7 @@ void append_memory_copy_region(ze_command_list_handle_t hCommandList,
 
   EXPECT_EQ(hCommandList, command_list_initial);
   EXPECT_EQ(hSignalEvent, signal_event_initial);
-  for (int i = 0; i < num_wait_events; i++) {
+  for (uint32_t i = 0U; i < num_wait_events; i++) {
     EXPECT_EQ(wait_events[i], wait_events_initial[i]);
   }
 }
@@ -390,7 +390,7 @@ void append_barrier(ze_command_list_handle_t cl, ze_event_handle_t hSignalEvent,
       cl, hSignalEvent, numWaitEvents, phWaitEvents));
   EXPECT_EQ(cl, command_list_initial);
   EXPECT_EQ(hSignalEvent, signal_event_initial);
-  for (int i = 0; i < numWaitEvents; i++) {
+  for (uint32_t i = 0U; i < numWaitEvents; i++) {
     EXPECT_EQ(phWaitEvents[i], wait_events_initial[i]);
   }
 }
@@ -420,7 +420,7 @@ void append_memory_ranges_barrier(ze_command_list_handle_t hCommandList,
       numWaitEvents, phWaitEvents));
   EXPECT_EQ(hCommandList, command_list_initial);
   EXPECT_EQ(hSignalEvent, signal_event_initial);
-  for (int i = 0; i < numWaitEvents; i++) {
+  for (uint32_t i = 0U; i < numWaitEvents; i++) {
     EXPECT_EQ(phWaitEvents[i], wait_events_initial[i]);
   }
 }
@@ -445,7 +445,7 @@ void append_launch_function(ze_command_list_handle_t hCommandList,
   EXPECT_EQ(hCommandList, command_list_initial);
   EXPECT_EQ(hFunction, function_initial);
   EXPECT_EQ(hSignalEvent, signal_event_initial);
-  for (int i = 0; i < numWaitEvents && phWaitEvents; i++) {
+  for (uint32_t i = 0U; i < numWaitEvents && phWaitEvents; i++) {
     EXPECT_EQ(phWaitEvents[i], wait_events_initial[i]);
   }
 }
@@ -470,7 +470,7 @@ void append_wait_on_events(ze_command_list_handle_t hCommandList,
   EXPECT_ZE_RESULT_SUCCESS(
       zeCommandListAppendWaitOnEvents(hCommandList, numEvents, phEvents));
   EXPECT_EQ(hCommandList, command_list_initial);
-  for (int i = 0; i < numEvents; i++) {
+  for (uint32_t i = 0U; i < numEvents; i++) {
     EXPECT_EQ(phEvents[i], events_initial[i]);
   }
 }
@@ -514,7 +514,7 @@ void append_image_copy(ze_command_list_handle_t hCommandList,
   EXPECT_EQ(hEvent, signal_event_initial);
   EXPECT_EQ(dst, dst_initial);
   EXPECT_EQ(src, src_initial);
-  for (int i = 0; i < num_wait_events; i++) {
+  for (uint32_t i = 0U; i < num_wait_events; i++) {
     EXPECT_EQ(wait_events[i], wait_events_initial[i]);
   }
 }
@@ -541,7 +541,7 @@ void append_image_copy_to_mem(ze_command_list_handle_t hCommandList, void *dst,
   EXPECT_EQ(hCommandList, command_list_initial);
   EXPECT_EQ(src, src_initial);
   EXPECT_EQ(hEvent, signal_event_initial);
-  for (int i = 0; i < num_wait_events; i++) {
+  for (uint32_t i = 0U; i < num_wait_events; i++) {
     EXPECT_EQ(wait_events[i], wait_events_initial[i]);
   }
 }
@@ -568,7 +568,7 @@ void append_image_copy_to_mem(ze_command_list_handle_t hCommandList, void *dst,
   EXPECT_EQ(hCommandList, command_list_initial);
   EXPECT_EQ(src, src_initial);
   EXPECT_EQ(hEvent, signal_event_initial);
-  for (int i = 0; i < num_wait_events; i++) {
+  for (uint32_t i = 0U; i < num_wait_events; i++) {
     EXPECT_EQ(wait_events[i], wait_events_initial[i]);
   }
 }
@@ -606,7 +606,7 @@ void append_image_copy_from_mem(ze_command_list_handle_t hCommandList,
   EXPECT_EQ(hCommandList, command_list_initial);
   EXPECT_EQ(dst, dst_initial);
   EXPECT_EQ(hEvent, signal_event_initial);
-  for (int i = 0; i < num_wait_events; i++) {
+  for (uint32_t i = 0U; i < num_wait_events; i++) {
     EXPECT_EQ(wait_events[i], wait_events_initial[i]);
   }
 }
@@ -628,7 +628,7 @@ void append_image_copy_from_mem(ze_command_list_handle_t hCommandList,
   EXPECT_EQ(hCommandList, command_list_initial);
   EXPECT_EQ(dst, dst_initial);
   EXPECT_EQ(hEvent, signal_event_initial);
-  for (int i = 0; i < num_wait_events; i++) {
+  for (uint32_t i = 0U; i < num_wait_events; i++) {
     EXPECT_EQ(wait_events[i], wait_events_initial[i]);
   }
 }
@@ -671,7 +671,7 @@ void append_image_copy_to_mem_ext(
   EXPECT_EQ(hCommandList, command_list_initial);
   EXPECT_EQ(src, src_initial);
   EXPECT_EQ(hEvent, signal_event_initial);
-  for (int i = 0; i < num_wait_events; i++) {
+  for (uint32_t i = 0U; i < num_wait_events; i++) {
     EXPECT_EQ(wait_events[i], wait_events_initial[i]);
   }
 }
@@ -694,7 +694,7 @@ void append_image_copy_to_mem_ext(
   EXPECT_EQ(hCommandList, command_list_initial);
   EXPECT_EQ(src, src_initial);
   EXPECT_EQ(hEvent, signal_event_initial);
-  for (int i = 0; i < num_wait_events; i++) {
+  for (uint32_t i = 0U; i < num_wait_events; i++) {
     EXPECT_EQ(wait_events[i], wait_events_initial[i]);
   }
 }
@@ -727,7 +727,7 @@ void append_image_copy_from_mem_ext(
   EXPECT_EQ(hCommandList, command_list_initial);
   EXPECT_EQ(dst, dst_initial);
   EXPECT_EQ(hEvent, signal_event_initial);
-  for (int i = 0; i < num_wait_events; i++) {
+  for (uint32_t i = 0U; i < num_wait_events; i++) {
     EXPECT_EQ(wait_events[i], wait_events_initial[i]);
   }
 }
@@ -762,7 +762,7 @@ void append_image_copy_from_mem_ext(
   EXPECT_EQ(hCommandList, command_list_initial);
   EXPECT_EQ(dst, dst_initial);
   EXPECT_EQ(hEvent, signal_event_initial);
-  for (int i = 0; i < num_wait_events; i++) {
+  for (uint32_t i = 0U; i < num_wait_events; i++) {
     EXPECT_EQ(wait_events[i], wait_events_initial[i]);
   }
 }
@@ -808,7 +808,7 @@ void append_image_copy_region(ze_command_list_handle_t hCommandList,
   EXPECT_EQ(hEvent, signal_event_initial);
   EXPECT_EQ(dst, dst_initial);
   EXPECT_EQ(src, src_initial);
-  for (int i = 0; i < num_wait_events; i++) {
+  for (uint32_t i = 0U; i < num_wait_events; i++) {
     EXPECT_EQ(wait_events[i], wait_events_initial[i]);
   }
 }

--- a/utils/test_harness/src/test_harness_cmdqueue.cpp
+++ b/utils/test_harness/src/test_harness_cmdqueue.cpp
@@ -130,7 +130,7 @@ void execute_command_lists(ze_command_queue_handle_t cq,
       cq, numCommandLists, phCommandLists, hFence));
   EXPECT_EQ(cq, command_queue_initial);
   EXPECT_EQ(hFence, fence_initial);
-  for (int i = 0; i < numCommandLists; i++) {
+  for (uint32_t i = 0U; i < numCommandLists; i++) {
     EXPECT_EQ(phCommandLists[i], command_lists_initial[i]);
   }
 }

--- a/utils/test_harness/src/test_harness_device.cpp
+++ b/utils/test_harness/src/test_harness_device.cpp
@@ -220,7 +220,7 @@ std::vector<ze_device_memory_properties_t> get_memory_properties_ext(
     std::vector<ze_device_memory_ext_properties_t> &extProperties) {
   std::vector<ze_device_memory_properties_t> properties(count);
   memset(properties.data(), 0, sizeof(ze_device_memory_properties_t) * count);
-  for (int i = 0; i < count; i++) {
+  for (uint32_t i = 0U; i < count; i++) {
     properties[i].stype = ZE_STRUCTURE_TYPE_DEVICE_MEMORY_PROPERTIES;
     extProperties[i].stype = ZE_STRUCTURE_TYPE_DEVICE_MEMORY_EXT_PROPERTIES;
     properties[i].pNext = &extProperties[i];

--- a/utils/test_harness/src/test_harness_event.cpp
+++ b/utils/test_harness/src/test_harness_event.cpp
@@ -54,7 +54,7 @@ create_event_pool(ze_context_handle_t context, ze_event_pool_desc_t desc,
   EXPECT_ZE_RESULT_SUCCESS(zeEventPoolCreate(context, &desc, devices.size(),
                                              devices.data(), &event_pool));
   EXPECT_EQ(context, context_initial);
-  for (int i = 0; i < devices.size(); i++) {
+  for (size_t i = 0U; i < devices.size(); i++) {
     EXPECT_EQ(devices[i], devices_initial[i]);
   }
   EXPECT_NE(nullptr, event_pool);
@@ -128,7 +128,7 @@ get_timestamp_global_duration(const ze_kernel_timestamp_result_t *timestamp,
   auto device_properties = lzt::get_device_properties(device, property_type);
   uint64_t timestamp_freq = device_properties.timerResolution;
   uint64_t timestamp_max_val =
-      ~(-1L << device_properties.kernelTimestampValidBits);
+      ~(-1ULL << device_properties.kernelTimestampValidBits);
 
   double timer_period = 0;
   if (property_type == ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES) {

--- a/utils/test_harness/src/test_harness_image.cpp
+++ b/utils/test_harness/src/test_harness_image.cpp
@@ -400,8 +400,8 @@ int compare_data_pattern(
             << " originY: " << region->originY
             << " originZ: " << region->originZ << " width: " << region->width
             << " height: " << region->height << std::endl;
-  for (unsigned row = 0; row < image.height(); row++) {
-    for (unsigned column = 0; column < image.width(); column++) {
+  for (uint32_t row = 0; row < image.height(); row++) {
+    for (uint32_t column = 0; column < image.width(); column++) {
       uint32_t pixel = image.get_pixel(column, row);
       const lzt::ImagePNG32Bit *expected_image;
       LOG_DEBUG << "row: " << row << " and column: " << column

--- a/utils/test_harness/src/test_harness_module.cpp
+++ b/utils/test_harness/src/test_harness_module.cpp
@@ -173,7 +173,7 @@ void dynamic_link(uint32_t num_modules, ze_module_handle_t *modules,
          sizeof(ze_module_handle_t) * num_modules);
   *result = zeModuleDynamicLink(num_modules, modules, link_log);
   EXPECT_ZE_RESULT_SUCCESS(*result);
-  for (int i = 0; i < num_modules; i++) {
+  for (uint32_t i = 0U; i < num_modules; i++) {
     EXPECT_EQ(modules[i], modules_initial[i]);
   }
 }

--- a/utils/test_harness/tools/src/test_harness_debug.cpp
+++ b/utils/test_harness/tools/src/test_harness_debug.cpp
@@ -160,13 +160,13 @@ bool get_register_set_props(ze_device_handle_t device,
   zetDebugGetRegisterSetProperties(device, &nRegSets, nullptr);
   zet_debug_regset_properties_t *pRegSets =
       new zet_debug_regset_properties_t[nRegSets];
-  for (int i = 0; i < nRegSets; i++) {
+  for (uint32_t i = 0U; i < nRegSets; i++) {
     pRegSets[i] = {ZET_STRUCTURE_TYPE_DEBUG_REGSET_PROPERTIES, nullptr};
   }
   zetDebugGetRegisterSetProperties(device, &nRegSets, pRegSets);
 
   bool found = false;
-  for (int i = 0; i < nRegSets; i++) {
+  for (uint32_t i = 0U; i < nRegSets; i++) {
     if (pRegSets[i].type == type) {
       printRegSetProperties(pRegSets[i]);
       reg = pRegSets[i];

--- a/utils/utils/src/utils.cpp
+++ b/utils/utils/src/utils.cpp
@@ -43,14 +43,14 @@ zes_driver_handle_t get_default_zes_driver() {
   ze_result_t result = ZE_RESULT_SUCCESS;
 
   static zes_driver_handle_t driver = nullptr;
-  int default_idx = 0;
+  uint32_t default_idx = 0U;
 
   if (driver)
     return driver;
 
   char *user_driver_index = getenv("LZT_DEFAULT_DRIVER_IDX");
   if (user_driver_index != nullptr) {
-    default_idx = std::stoi(user_driver_index);
+    default_idx = static_cast<uint32_t>(std::stoul(user_driver_index));
   }
 
   std::vector<zes_driver_handle_t> drivers =
@@ -59,7 +59,7 @@ zes_driver_handle_t get_default_zes_driver() {
     throw std::runtime_error("zesDriverGet failed: " + to_string(result));
   }
 
-  if (default_idx >= drivers.size()) {
+  if (default_idx >= static_cast<uint32_t>(drivers.size())) {
     LOG_ERROR << "Default Driver index " << default_idx
               << " invalid on this machine.";
     throw std::runtime_error("Get Default Driver failed");
@@ -97,14 +97,14 @@ ze_driver_handle_t get_default_driver() {
   ze_result_t result = ZE_RESULT_SUCCESS;
 
   static ze_driver_handle_t driver = nullptr;
-  int default_idx = 0;
+  uint32_t default_idx = 0U;
 
   if (driver)
     return driver;
 
   char *user_driver_index = getenv("LZT_DEFAULT_DRIVER_IDX");
   if (user_driver_index != nullptr) {
-    default_idx = std::stoi(user_driver_index);
+    default_idx = static_cast<uint32_t>(std::stoul(user_driver_index));
   }
 
   std::vector<ze_driver_handle_t> drivers =
@@ -113,7 +113,7 @@ ze_driver_handle_t get_default_driver() {
     throw std::runtime_error("zeDriverGet failed: " + to_string(result));
   }
 
-  if (default_idx >= drivers.size()) {
+  if (default_idx >= static_cast<uint32_t>(drivers.size())) {
     LOG_ERROR << "Default Driver index " << default_idx
               << " invalid on this machine.";
     throw std::runtime_error("Get Default Driver failed");
@@ -167,14 +167,14 @@ ze_device_handle_t get_default_device(ze_driver_handle_t driver) {
   ze_result_t result = ZE_RESULT_SUCCESS;
 
   static ze_device_handle_t device = nullptr;
-  int default_idx = 0;
+  uint32_t default_idx = 0U;
   char *default_name = nullptr;
   if (device)
     return device;
 
   char *user_device_index = getenv("LZT_DEFAULT_DEVICE_IDX");
   if (user_device_index != nullptr) {
-    default_idx = std::stoi(user_device_index);
+    default_idx = static_cast<uint32_t>(std::stoul(user_device_index));
   }
   default_name = getenv("LZT_DEFAULT_DEVICE_NAME");
 
@@ -201,7 +201,7 @@ ze_device_handle_t get_default_device(ze_driver_handle_t driver) {
       throw std::runtime_error("Get Default Device failed");
     }
   } else {
-    if (default_idx >= devices.size()) {
+    if (default_idx >= static_cast<uint32_t>(devices.size())) {
       LOG_ERROR << "Default Device index " << default_idx
                 << " invalid on this machine.";
       throw std::runtime_error("Get Default Device failed");


### PR DESCRIPTION
Several hundred type cast warnings appear when compiling the Level-Zero CTS public & embargo code. This leads to important warnings being overlooked because they are buried with the hundreds of sign mismatch warnings.

This task will remove these warnings by applying the appropriate type conversions.

This PR only fixes those warnings related to mismatched type warnings during comparisons (i.e., "-Wsign-compare" and "-Wnarrowing"). A future PR will fix other warnings (e.g., "-Wunused-variable", "-Wparentheses", "-Wdangling-else", etc.) with the ultimate goal to remove all warnings ("-Wall -Wextra -Wpedantic").

Also, this PR is for the warnings in the public Level-Zero CTS repository. A similar PR will be submitted for the embargo CTS repository components once this PR has been merged.