### PR TITLE
Fix 1000x event-timer bandwidth bug

### DIFF
--- a/perf_tests/ze_peak/src/ze_peak.cpp
+++ b/perf_tests/ze_peak/src/ze_peak.cpp
@@ -1115,7 +1115,7 @@ long double ZePeak::run_kernel(L0Context context, ze_kernel_handle_t &function,
                                  std::to_string(result));
       }
 
-      timed += context_time_in_us(context, function_event);
+      timed += context_time_in_us(context, function_event) * 1000.0L;
 
       if (context.sub_device_count) {
         if (context.sub_device_count == current_sub_device_id + 1) {


### PR DESCRIPTION
BANDWIDTH_EVENT_TIMING accumulated microseconds (context_time_in_us) but calculate_gbps() expects nanoseconds, so -e reported bandwidth/GFLOPS ~1000x high. Convert us->ns at that call site only.